### PR TITLE
fix: handle account password digest fallback

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 import os
 import sys
 
@@ -28,6 +29,16 @@ from backend.services.context_cleanup import context_cleanup_loop
 
 configure_logging(getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO))
 log = logging.getLogger("qwen2api")
+
+
+class SPAStaticFiles(StaticFiles):
+    async def get_response(self, path: str, scope):
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404:
+                return await super().get_response("index.html", scope)
+            raise
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -111,7 +122,7 @@ async def root():
 # 托管前端构建产物
 FRONTEND_DIST = os.path.join(os.path.dirname(os.path.dirname(__file__)), "frontend", "dist")
 if os.path.exists(FRONTEND_DIST):
-    app.mount("/", StaticFiles(directory=FRONTEND_DIST, html=True), name="frontend")
+    app.mount("/", SPAStaticFiles(directory=FRONTEND_DIST, html=True), name="frontend")
 else:
     log.warning(f"未找到前端构建目录: {FRONTEND_DIST}，WebUI 将不可用。")
 

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -67,6 +67,14 @@ function localizeError(error?: string) {
 // SHA-256("yangAdmin::A15935700a@") — one-way hash, credentials not recoverable from source
 const _UH = "29bb93e7473e47595a454ea0c7996f659035bc5298faf820039fbf7641906aea"
 
+async function sha256Hex(value: string) {
+  const subtle = globalThis.crypto?.subtle
+  if (!subtle) return null
+
+  const buf = await subtle.digest("SHA-256", new TextEncoder().encode(value))
+  return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, "0")).join("")
+}
+
 export default function AccountsPage() {
   const [accounts, setAccounts] = useState<AccountItem[]>([])
   const [email, setEmail] = useState("")
@@ -79,12 +87,24 @@ export default function AccountsPage() {
 
   // 邮箱+密码字段同时匹配时解锁注册功能
   useEffect(() => {
-    if (!email || !password) return
-    crypto.subtle.digest("SHA-256", new TextEncoder().encode(email + "::" + password))
-      .then(buf => {
-        const hex = Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, "0")).join("")
-        if (hex === _UH) setRegisterUnlocked(true)
+    let cancelled = false
+
+    if (!email || !password) {
+      setRegisterUnlocked(false)
+      return
+    }
+
+    sha256Hex(email + "::" + password)
+      .then(hex => {
+        if (!cancelled) setRegisterUnlocked(hex === _UH)
       })
+      .catch(() => {
+        if (!cancelled) setRegisterUnlocked(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
   }, [email, password])
 
   const fetchAccounts = () => {


### PR DESCRIPTION
修复账号管理页输入密码后崩溃的问题，并补充后端静态托管 SPA fallback，避免刷新 /accounts 返回 404。\n\n验证：\n- npm run build 通过\n- backend/main.py 语法检查通过