### PR TITLE
feat(i18n): add English + Portuguese (pt-BR) UI translation

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -138,7 +138,7 @@ async def add_account(request: Request):
 
     is_valid = await client.verify_token(token)
     if not is_valid:
-        return {"ok": False, "error": "Invalid token (验证失败，请确认Token有效)"}
+        return {"ok": False, "error": "Invalid token. Please ensure the Token is valid."}
 
     await pool.add(acc)
     return {"ok": True, "email": acc.email}
@@ -173,17 +173,17 @@ async def register_new_account(request: Request):
     # 简单的频率限制保护
     current = len(pool.accounts)
     if current >= 100:
-        return {"ok": False, "error": "账号池已满，请先清理死号"}
+        return {"ok": False, "error": "Account pool is full. Please clean up dead accounts first."}
 
     try:
         acc = await register_qwen_account()
         if acc:
             await pool.add(acc)
             log.info(f"[注册] 注册成功: {acc.email}（当前账号数: {len(pool.accounts)}/100）")
-            return {"ok": True, "email": acc.email, "message": "新账号注册成功并已入池"}
-        return {"ok": False, "error": "自动化注册失败，可能遇到风控或页面元素改变"}
+            return {"ok": True, "email": acc.email, "message": "New account registered and added to the pool."}
+        return {"ok": False, "error": "Auto-registration failed. May be due to anti-bot detection or page changes."}
     except Exception as e:
-        return {"ok": False, "error": f"注册发生异常: {str(e)}"}
+        return {"ok": False, "error": f"Registration error: {str(e)}"}
 
 @router.post("/verify", dependencies=[Depends(verify_admin)])
 async def verify_all_accounts(request: Request):
@@ -222,7 +222,7 @@ async def activate_account(email: str, request: Request):
 
     # 防止并发点击：检查一个运行时标志
     if getattr(acc, "_is_activating", False):
-        return {"ok": False, "error": "该账号正在激活中，请勿重复点击"}
+        return {"ok": False, "error": "This account is being activated. Please do not click repeatedly."}
 
     try:
         setattr(acc, "_is_activating", True)
@@ -231,8 +231,8 @@ async def activate_account(email: str, request: Request):
             acc.valid = True
             acc.activation_pending = False
             await pool.add(acc) # 这会触发覆盖保存
-            return {"ok": True, "message": "账号激活成功"}
-        return {"ok": False, "error": "未能找到激活链接或获取Token"}
+            return {"ok": True, "message": "Account activated successfully."}
+        return {"ok": False, "error": "Could not find activation link or obtain Token."}
     finally:
         setattr(acc, "_is_activating", False)
 

--- a/backend/core/account_pool/pool_core.py
+++ b/backend/core/account_pool/pool_core.py
@@ -69,15 +69,15 @@ class Account:
 
     def get_status_text(self) -> str:
         status_map = {
-            "valid": "正常",
-            "pending_activation": "待激活",
-            "rate_limited": "限流",
-            "banned": "封禁",
-            "auth_error": "鉴权失败",
-            "invalid": "失效",
-            "unknown": "未知",
+            "valid": "Available",
+            "pending_activation": "Pending activation",
+            "rate_limited": "Rate-limited",
+            "banned": "Banned",
+            "auth_error": "Auth error",
+            "invalid": "Invalid",
+            "unknown": "Unknown",
         }
-        return status_map.get(self.get_status_code(), "未知")
+        return status_map.get(self.get_status_code(), "Unknown")
 
     def to_dict(self):
         return {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,9 +12,12 @@
         "@tailwindcss/vite": "^4.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "i18next": "^23.16.0",
+        "i18next-browser-languagedetector": "^8.0.0",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-i18next": "^15.1.0",
         "react-router-dom": "^7.14.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
@@ -269,6 +272,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2865,6 +2877,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3561,6 +3614,32 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.4.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3835,7 +3914,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3989,6 +4068,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,12 @@
     "@tailwindcss/vite": "^4.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "i18next": "^23.16.0",
+    "i18next-browser-languagedetector": "^8.0.0",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-i18next": "^15.1.0",
     "react-router-dom": "^7.14.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,29 @@
+import i18n from "i18next"
+import LanguageDetector from "i18next-browser-languagedetector"
+import { initReactI18next } from "react-i18next"
+
+import en from "./locales/en.json"
+import ptBR from "./locales/pt-BR.json"
+
+export const SUPPORTED_LNGS = ["en", "pt-BR"] as const
+export type SupportedLng = (typeof SUPPORTED_LNGS)[number]
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      "pt-BR": { translation: ptBR },
+    },
+    fallbackLng: "en",
+    supportedLngs: SUPPORTED_LNGS as unknown as string[],
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ["localStorage", "navigator", "htmlTag"],
+      caches: ["localStorage"],
+      lookupLocalStorage: "qwen2api_lang",
+    },
+  })
+
+export default i18n

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -4,8 +4,9 @@ import { initReactI18next } from "react-i18next"
 
 import en from "./locales/en.json"
 import ptBR from "./locales/pt-BR.json"
+import zh from "./locales/zh.json"
 
-export const SUPPORTED_LNGS = ["en", "pt-BR"] as const
+export const SUPPORTED_LNGS = ["en", "pt-BR", "zh"] as const
 export type SupportedLng = (typeof SUPPORTED_LNGS)[number]
 
 i18n
@@ -15,9 +16,11 @@ i18n
     resources: {
       en: { translation: en },
       "pt-BR": { translation: ptBR },
+      zh: { translation: zh },
     },
     fallbackLng: "en",
     supportedLngs: SUPPORTED_LNGS as unknown as string[],
+    nonExplicitSupportedLngs: true,
     interpolation: { escapeValue: false },
     detection: {
       order: ["localStorage", "navigator", "htmlTag"],

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -14,7 +14,8 @@
     "delete": "Delete",
     "saveFailed": "Save failed",
     "languageEN": "English",
-    "languagePT": "Português (BR)"
+    "languagePT": "Português (BR)",
+    "languageZH": "中文"
   },
   "dashboard": {
     "title": "Status",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,0 +1,245 @@
+{
+  "nav": {
+    "dashboard": "Status",
+    "accounts": "Accounts",
+    "apiKey": "API Keys",
+    "test": "Playground",
+    "images": "Images",
+    "settings": "Settings"
+  },
+  "common": {
+    "save": "Save",
+    "clear": "Clear",
+    "refresh": "Refresh",
+    "delete": "Delete",
+    "saveFailed": "Save failed",
+    "languageEN": "English",
+    "languagePT": "Português (BR)"
+  },
+  "dashboard": {
+    "title": "Status",
+    "subtitle": "Global concurrency monitoring and Qwen account pool overview (auto-refresh every 3s).",
+    "fetchFailed": "Failed to fetch status. Please check your session Key in 'Settings'.",
+    "stats": {
+      "available": "Available accounts",
+      "availableSub": "{{total}} total",
+      "concurrent": "Active concurrency",
+      "concurrentSub": "Global active {{limit}}",
+      "queued": "Queued requests",
+      "queuedSub": "Queue limit {{limit}}",
+      "rateLimited": "Rate-limited / invalid",
+      "chatIdPool": "Chat_ID warm pool",
+      "chatIdPoolSub": "Target/account {{target}} · TTL {{ttl}} min",
+      "chatIdPoolDisabled": "Disabled",
+      "asyncTasks": "Async tasks"
+    },
+    "accountTable": {
+      "title": "Account concurrency details",
+      "email": "Email",
+      "status": "Status",
+      "inflight": "In-flight",
+      "warmChat": "Warm chat_id",
+      "failures": "Failures",
+      "rateLimitHits": "Rate-limit hits"
+    },
+    "endpoints": {
+      "title": "API endpoint pool",
+      "subtitle": "Entry points compatible with mainstream AI protocols. Auth is optional or via API Key.",
+      "health": "Health"
+    }
+  },
+  "accounts": {
+    "title": "Account management",
+    "subtitle": "Unified management of the upstream account pool. Distinguishes pending activation, rate-limited, banned and invalid states.",
+    "verifyAll": "Verify all",
+    "refresh": "Refresh status",
+    "autoRegister": "One-click new account",
+    "registering": "Registering...",
+    "stats": {
+      "valid": "Available",
+      "pending": "Pending activation",
+      "rateLimited": "Rate-limited",
+      "banned": "Banned",
+      "invalid": "Other invalid"
+    },
+    "status": {
+      "valid": "Available",
+      "pendingActivation": "Pending activation",
+      "rateLimited": "Rate-limited",
+      "banned": "Banned",
+      "authError": "Auth error",
+      "invalid": "Invalid"
+    },
+    "noteRecoverIn": "Recovers in ~{{seconds}}s",
+    "errors": {
+      "unknown": "Unknown error",
+      "activationInProgress": "Account is being activated, please refresh later",
+      "activationLinkMissing": "Could not find activation link or token",
+      "tokenInvalid": "Token invalid or authentication failed",
+      "refreshAccountsFailed": "Failed to refresh accounts. Check your session Key.",
+      "tokenRequired": "Please provide a Token",
+      "registrationFailed": "Account registration failed",
+      "registrationRequestFailed": "Account registration request failed",
+      "autoRegisterFailed": "Auto-register failed",
+      "autoRegisterRequestFailed": "Auto-register request failed",
+      "deleteAccountFailed": "Failed to delete account",
+      "verifyRequestFailed": "Verify request failed",
+      "verifyAllFailed": "Bulk verify failed",
+      "verifyAllRequestFailed": "Bulk verify request failed",
+      "activateRequestFailed": "Activate request failed"
+    },
+    "messages": {
+      "injectingAccount": "Injecting account...",
+      "accountAdded": "Account joined the pool",
+      "deleting": "Deleting {{email}}...",
+      "deleted": "Deleted {{email}}",
+      "autoRegistering": "Auto-registering, please wait...",
+      "registeredPending": "Account registered but still requires activation: {{email}}",
+      "registeredSuccess": "Registered: {{email}}",
+      "verifying": "Verifying {{email}}...",
+      "verifyPassed": "Verification passed: {{email}}",
+      "verifyFailed": "Verification failed: {{detail}}",
+      "verifyingAll": "Bulk verifying all accounts...",
+      "verifyAllDone": "Bulk verify done, concurrency: {{n}}",
+      "activating": "Activating {{email}}...",
+      "activatingPending": "Account is being activated, please refresh later: {{email}}",
+      "activationOk": "Activation successful: {{email}}",
+      "activationFailed": "Activation failed: {{detail}}",
+      "accountsRefreshed": "Account list refreshed"
+    },
+    "form": {
+      "manualTitle": "Manually inject account",
+      "manualDesc": "Log in at chat.qwen.ai first, press F12 to open DevTools, look up the token in Application / Storage › Local Storage and paste the raw value below.",
+      "warningTitle": "Important: paste ONLY the raw token value from Local Storage. Do NOT extract from Network requests or Authorization headers.",
+      "warningSub": "Do not include the 'Bearer' prefix or paste any Authorization text. Email and password are optional; the system validates the token before injecting.",
+      "tokenLabel": "Token (required)",
+      "tokenPlaceholder": "Paste the raw token copied from Local Storage",
+      "emailLabel": "Email (optional)",
+      "emailPlaceholder": "Email address",
+      "passwordLabel": "Password (optional)",
+      "passwordPlaceholder": "Used for auto-refresh or activation",
+      "submitAdd": "Inject account"
+    },
+    "table": {
+      "title": "Account list",
+      "email": "Account",
+      "status": "Status",
+      "load": "Concurrency load",
+      "loadUnit": "threads",
+      "note": "Note",
+      "action": "Actions",
+      "empty": "No accounts yet. Inject manually or use one-click new account.",
+      "activate": "Activate",
+      "verifySingle": "Verify",
+      "deleteAccount": "Delete account"
+    }
+  },
+  "tokens": {
+    "title": "API Key distribution",
+    "subtitle": "Manage credentials that can access this gateway.",
+    "refresh": "Refresh",
+    "refreshed": "Refreshed",
+    "generate": "Generate new Key",
+    "generated": "New API Key generated",
+    "generateFailed": "Generation failed, please check permissions",
+    "deleted": "API Key deleted",
+    "deleteFailed": "Deletion failed",
+    "fetchFailed": "Refresh failed, please check your session Key",
+    "table": {
+      "index": "#",
+      "actions": "Actions",
+      "empty": "No API Keys"
+    }
+  },
+  "test": {
+    "title": "Endpoint test",
+    "subtitle": "Test whether your API distribution is working correctly.",
+    "modelLabel": "Model:",
+    "stream": "Stream",
+    "clear": "Clear chat",
+    "empty": "Send a message to start testing. The system will call /v1/chat/completions.",
+    "thinking": "Thinking...",
+    "thinkingProcess": "Reasoning",
+    "thinkingChars": "{{n}} chars",
+    "inputPlaceholder": "Type a test message...",
+    "emptyResponse": "Empty response (account may be inactive or unavailable)",
+    "networkError": "Network error: {{message}}",
+    "unknownResponse": "Unknown response: {{response}}"
+  },
+  "images": {
+    "title": "Image generation",
+    "subtitle": "Generate AI images via Qwen3.6-Plus. Multiple aspect ratios supported.",
+    "promptLabel": "Image description (Prompt)",
+    "promptPlaceholder": "Describe the image you want to generate. e.g.: cyberpunk style cat, neon lights, ultra-realistic style",
+    "promptTip": "Ctrl+Enter for quick generate",
+    "ratioLabel": "Aspect ratio",
+    "countLabel": "Count",
+    "countSuffix": "{{n}}",
+    "generate": "Generate image",
+    "generating": "Generating...",
+    "noImagesReturned": "No images returned, please try again",
+    "generatedSuccess": "Generated {{n}} image(s)",
+    "generationFailed": "Generation failed: {{detail}}",
+    "networkError": "Network error",
+    "imageLoadFailed": "Failed to load image",
+    "loadingState": "Generating image...",
+    "loadingHint": "Image generation usually takes 10-30 seconds, please wait",
+    "resultsTitle": "Results ({{n}})",
+    "clearAll": "Clear",
+    "download": "Download",
+    "openInNewWindow": "Open in new window",
+    "emptyTitle": "No images yet",
+    "emptyHint": "Enter a description above and click 'Generate image' to start"
+  },
+  "settings": {
+    "title": "System settings",
+    "subtitle": "Manage console authentication and gateway runtime configuration.",
+    "refreshConfig": "Refresh config",
+    "configRefreshed": "Configuration refreshed",
+    "fetchFailed": "Failed to fetch configuration. Please check your session Key.",
+    "sessionKey": {
+      "title": "Current session Key",
+      "subtitle": "Paste your existing API Key here. The console will use it for all admin operations. (Stored in browser local storage.)",
+      "placeholder": "sk-qwen-... or default admin key 'admin'",
+      "keyRequired": "Please enter a Key",
+      "saved": "Key saved locally, refreshing data...",
+      "cleared": "Key cleared"
+    },
+    "connection": {
+      "title": "Connection info",
+      "baseUrlLabel": "API base URL"
+    },
+    "core": {
+      "title": "Core concurrency",
+      "subtitle": "Runtime concurrency slots and queue thresholds (changes apply immediately).",
+      "version": "Current system version",
+      "maxInflightLabel": "Max inflight per account (max_inflight_per_account)",
+      "maxInflightDesc": "Concurrent requests per upstream account. Too high may get banned, too low underutilizes.",
+      "globalMaxInflightLabel": "Global inflight cap (global_max_inflight)",
+      "globalMaxInflightDesc": "Hard cap on total concurrent requests across all accounts. 0 = unlimited. Maps to Dashboard 'Async tasks' peak.",
+      "saveConcurrency": "Save concurrency settings",
+      "saveConcurrencyToast": "Concurrency settings saved (applied immediately)"
+    },
+    "pool": {
+      "title": "Chat_ID warm pool",
+      "subtitle": "Pre-built chat_ids skip the upstream /chats/new handshake (0.5~6s). Runtime changes apply immediately.",
+      "targetLabel": "Target per account (target)",
+      "targetDesc": "How many chat_ids to pre-warm per account. Default 5.",
+      "ttlLabel": "TTL (minutes)",
+      "ttlDesc": "Discard chat_ids older than this. Default 10.",
+      "savePool": "Save warm pool settings",
+      "savePoolToast": "Warm pool settings saved (effective from next refresh)"
+    },
+    "modelAliases": {
+      "title": "Automatic model mapping (Model Aliases)",
+      "subtitle": "Incoming model names will be routed by the gateway to the following actual Qwen models. Edit as standard JSON.",
+      "saveAliases": "Save mapping",
+      "saveAliasesToast": "Model aliases updated",
+      "jsonError": "JSON syntax error, please check"
+    },
+    "saveFailed": "Save failed",
+    "example": {
+      "title": "Usage examples"
+    }
+  }
+}

--- a/frontend/src/i18n/locales/pt-BR.json
+++ b/frontend/src/i18n/locales/pt-BR.json
@@ -1,0 +1,245 @@
+{
+  "nav": {
+    "dashboard": "Status",
+    "accounts": "Contas",
+    "apiKey": "API Keys",
+    "test": "Playground",
+    "images": "Imagens",
+    "settings": "Configurações"
+  },
+  "common": {
+    "save": "Salvar",
+    "clear": "Limpar",
+    "refresh": "Atualizar",
+    "delete": "Excluir",
+    "saveFailed": "Falha ao salvar",
+    "languageEN": "English",
+    "languagePT": "Português (BR)"
+  },
+  "dashboard": {
+    "title": "Status",
+    "subtitle": "Monitoramento global de concorrência e visão do pool de contas Qwen (atualização a cada 3s).",
+    "fetchFailed": "Falha ao buscar status. Verifique sua chave de sessão em 'Configurações'.",
+    "stats": {
+      "available": "Contas disponíveis",
+      "availableSub": "{{total}} no total",
+      "concurrent": "Concorrência ativa",
+      "concurrentSub": "Ativo global {{limit}}",
+      "queued": "Requisições na fila",
+      "queuedSub": "Limite da fila {{limit}}",
+      "rateLimited": "Rate-limit / inválido",
+      "chatIdPool": "Pool de aquecimento Chat_ID",
+      "chatIdPoolSub": "Meta/conta {{target}} · TTL {{ttl}} min",
+      "chatIdPoolDisabled": "Desativado",
+      "asyncTasks": "Tarefas assíncronas"
+    },
+    "accountTable": {
+      "title": "Detalhes de concorrência por conta",
+      "email": "Email",
+      "status": "Status",
+      "inflight": "Em curso",
+      "warmChat": "chat_id aquecido",
+      "failures": "Falhas",
+      "rateLimitHits": "Rate-limit hits"
+    },
+    "endpoints": {
+      "title": "Pool de endpoints da API",
+      "subtitle": "Entradas compatíveis com os principais protocolos de IA. Autenticação opcional ou via API Key.",
+      "health": "Saúde"
+    }
+  },
+  "accounts": {
+    "title": "Gerenciamento de contas",
+    "subtitle": "Gerencie de forma unificada o pool de contas upstream. Diferencia pendente de ativação, rate-limited, banida e inválida.",
+    "verifyAll": "Verificar todas",
+    "refresh": "Atualizar status",
+    "autoRegister": "Nova conta automática",
+    "registering": "Registrando...",
+    "stats": {
+      "valid": "Disponíveis",
+      "pending": "Pendente de ativação",
+      "rateLimited": "Rate-limited",
+      "banned": "Banidas",
+      "invalid": "Outras inválidas"
+    },
+    "status": {
+      "valid": "Disponível",
+      "pendingActivation": "Pendente ativação",
+      "rateLimited": "Rate-limited",
+      "banned": "Banida",
+      "authError": "Erro de auth",
+      "invalid": "Inválida"
+    },
+    "noteRecoverIn": "Recupera em ~{{seconds}}s",
+    "errors": {
+      "unknown": "Erro desconhecido",
+      "activationInProgress": "A conta está sendo ativada, tente atualizar mais tarde",
+      "activationLinkMissing": "Não foi possível encontrar o link de ativação ou o token",
+      "tokenInvalid": "Token inválido ou autenticação falhou",
+      "refreshAccountsFailed": "Falha ao atualizar contas. Verifique sua chave de sessão.",
+      "tokenRequired": "Por favor, informe um Token",
+      "registrationFailed": "Falha no registro da conta",
+      "registrationRequestFailed": "Falha na requisição de registro da conta",
+      "autoRegisterFailed": "Auto-registro falhou",
+      "autoRegisterRequestFailed": "Requisição de auto-registro falhou",
+      "deleteAccountFailed": "Falha ao excluir a conta",
+      "verifyRequestFailed": "Requisição de verificação falhou",
+      "verifyAllFailed": "Verificação em lote falhou",
+      "verifyAllRequestFailed": "Requisição de verificação em lote falhou",
+      "activateRequestFailed": "Requisição de ativação falhou"
+    },
+    "messages": {
+      "injectingAccount": "Injetando conta...",
+      "accountAdded": "Conta adicionada ao pool",
+      "deleting": "Excluindo {{email}}...",
+      "deleted": "Excluída {{email}}",
+      "autoRegistering": "Registrando automaticamente, aguarde...",
+      "registeredPending": "Conta registrada mas ainda precisa de ativação: {{email}}",
+      "registeredSuccess": "Registrada: {{email}}",
+      "verifying": "Verificando {{email}}...",
+      "verifyPassed": "Verificação ok: {{email}}",
+      "verifyFailed": "Verificação falhou: {{detail}}",
+      "verifyingAll": "Verificando todas as contas em paralelo...",
+      "verifyAllDone": "Verificação em lote concluída, concorrência: {{n}}",
+      "activating": "Ativando {{email}}...",
+      "activatingPending": "Conta está sendo ativada, atualize mais tarde: {{email}}",
+      "activationOk": "Ativação bem-sucedida: {{email}}",
+      "activationFailed": "Ativação falhou: {{detail}}",
+      "accountsRefreshed": "Lista de contas atualizada"
+    },
+    "form": {
+      "manualTitle": "Injetar conta manualmente",
+      "manualDesc": "Faça login em chat.qwen.ai, pressione F12 para abrir o DevTools, encontre o token em Application / Storage › Local Storage e cole o valor bruto abaixo.",
+      "warningTitle": "Importante: cole APENAS o valor bruto do token vindo do Local Storage. NÃO extraia da aba Network ou de cabeçalhos Authorization.",
+      "warningSub": "Não inclua o prefixo 'Bearer' nem cole texto Authorization inteiro. Email e senha são opcionais; o sistema valida o token antes de injetar.",
+      "tokenLabel": "Token (obrigatório)",
+      "tokenPlaceholder": "Cole o token bruto copiado do Local Storage",
+      "emailLabel": "Email (opcional)",
+      "emailPlaceholder": "Endereço de email",
+      "passwordLabel": "Senha (opcional)",
+      "passwordPlaceholder": "Usada para auto-refresh ou ativação",
+      "submitAdd": "Injetar conta"
+    },
+    "table": {
+      "title": "Lista de contas",
+      "email": "Conta",
+      "status": "Status",
+      "load": "Carga de concorrência",
+      "loadUnit": "threads",
+      "note": "Observação",
+      "action": "Ações",
+      "empty": "Sem contas. Injete manualmente ou use a opção de nova conta automática.",
+      "activate": "Ativar",
+      "verifySingle": "Verificar",
+      "deleteAccount": "Excluir conta"
+    }
+  },
+  "tokens": {
+    "title": "Distribuição de API Keys",
+    "subtitle": "Gerencie credenciais que podem acessar este gateway.",
+    "refresh": "Atualizar",
+    "refreshed": "Atualizado",
+    "generate": "Gerar nova Key",
+    "generated": "Nova API Key gerada",
+    "generateFailed": "Falha ao gerar, verifique permissões",
+    "deleted": "API Key excluída",
+    "deleteFailed": "Falha ao excluir",
+    "fetchFailed": "Falha ao atualizar, verifique sua chave de sessão",
+    "table": {
+      "index": "#",
+      "actions": "Ações",
+      "empty": "Sem API Keys"
+    }
+  },
+  "test": {
+    "title": "Teste de endpoint",
+    "subtitle": "Teste se sua distribuição de API está funcionando.",
+    "modelLabel": "Modelo:",
+    "stream": "Streaming",
+    "clear": "Limpar conversa",
+    "empty": "Envie uma mensagem para iniciar o teste. O sistema chamará /v1/chat/completions.",
+    "thinking": "Pensando...",
+    "thinkingProcess": "Raciocínio",
+    "thinkingChars": "{{n}} caracteres",
+    "inputPlaceholder": "Digite uma mensagem de teste...",
+    "emptyResponse": "Resposta vazia (conta pode estar inativa ou indisponível)",
+    "networkError": "Erro de rede: {{message}}",
+    "unknownResponse": "Resposta desconhecida: {{response}}"
+  },
+  "images": {
+    "title": "Geração de imagens",
+    "subtitle": "Gere imagens com IA via Qwen3.6-Plus. Múltiplas proporções suportadas.",
+    "promptLabel": "Descrição da imagem (Prompt)",
+    "promptPlaceholder": "Descreva a imagem que quer gerar. Ex.: gato estilo cyberpunk, luzes neon, ultra-realista",
+    "promptTip": "Ctrl+Enter gera rapidamente",
+    "ratioLabel": "Proporção",
+    "countLabel": "Quantidade",
+    "countSuffix": "{{n}}",
+    "generate": "Gerar imagem",
+    "generating": "Gerando...",
+    "noImagesReturned": "Nenhuma imagem retornada, tente novamente",
+    "generatedSuccess": "Geradas {{n}} imagem(ns)",
+    "generationFailed": "Falha na geração: {{detail}}",
+    "networkError": "Erro de rede",
+    "imageLoadFailed": "Falha ao carregar a imagem",
+    "loadingState": "Gerando imagem...",
+    "loadingHint": "A geração geralmente leva 10-30 segundos, aguarde",
+    "resultsTitle": "Resultados ({{n}})",
+    "clearAll": "Limpar",
+    "download": "Baixar",
+    "openInNewWindow": "Abrir em nova janela",
+    "emptyTitle": "Sem imagens",
+    "emptyHint": "Digite uma descrição acima e clique em 'Gerar imagem' para começar"
+  },
+  "settings": {
+    "title": "Configurações do sistema",
+    "subtitle": "Gerencie a autenticação do console e a configuração runtime do gateway.",
+    "refreshConfig": "Atualizar configurações",
+    "configRefreshed": "Configurações atualizadas",
+    "fetchFailed": "Falha ao buscar configurações. Verifique sua chave de sessão.",
+    "sessionKey": {
+      "title": "Chave de sessão atual",
+      "subtitle": "Cole aqui sua API Key existente. O console usará para todas as operações administrativas. (Armazenada no localStorage do navegador.)",
+      "placeholder": "sk-qwen-... ou chave admin padrão 'admin'",
+      "keyRequired": "Por favor, informe uma Key",
+      "saved": "Key salva localmente, atualizando dados...",
+      "cleared": "Key removida"
+    },
+    "connection": {
+      "title": "Informações de conexão",
+      "baseUrlLabel": "URL base da API"
+    },
+    "core": {
+      "title": "Concorrência principal",
+      "subtitle": "Slots de concorrência runtime e limites de fila (mudanças aplicadas imediatamente).",
+      "version": "Versão atual do sistema",
+      "maxInflightLabel": "Inflight máximo por conta (max_inflight_per_account)",
+      "maxInflightDesc": "Requisições simultâneas por conta upstream. Alto demais banimento; baixo demais subutiliza.",
+      "globalMaxInflightLabel": "Inflight cap global (global_max_inflight)",
+      "globalMaxInflightDesc": "Limite total de requisições simultâneas. 0 = ilimitado. Mapeia ao pico de 'Tarefas assíncronas' no Dashboard.",
+      "saveConcurrency": "Salvar concorrência",
+      "saveConcurrencyToast": "Concorrência salva (aplicada imediatamente)"
+    },
+    "pool": {
+      "title": "Pool de aquecimento Chat_ID",
+      "subtitle": "Chat_ids pré-criados evitam o handshake upstream /chats/new (0.5~6s). Mudanças aplicadas imediatamente.",
+      "targetLabel": "Meta por conta (target)",
+      "targetDesc": "Quantos chat_ids pré-aquecer por conta. Padrão 5.",
+      "ttlLabel": "TTL (minutos)",
+      "ttlDesc": "Descartar chat_ids mais antigos que isto. Padrão 10.",
+      "savePool": "Salvar pool de aquecimento",
+      "savePoolToast": "Pool salvo (vigente a partir do próximo refresh)"
+    },
+    "modelAliases": {
+      "title": "Mapeamento automático de modelos (Model Aliases)",
+      "subtitle": "Nomes de modelo recebidos serão roteados para os modelos Qwen reais abaixo. Edite como JSON padrão.",
+      "saveAliases": "Salvar mapeamento",
+      "saveAliasesToast": "Mapeamento de modelos atualizado",
+      "jsonError": "Erro de sintaxe JSON, verifique"
+    },
+    "saveFailed": "Falha ao salvar",
+    "example": {
+      "title": "Exemplos de uso"
+    }
+  }
+}

--- a/frontend/src/i18n/locales/pt-BR.json
+++ b/frontend/src/i18n/locales/pt-BR.json
@@ -14,7 +14,8 @@
     "delete": "Excluir",
     "saveFailed": "Falha ao salvar",
     "languageEN": "English",
-    "languagePT": "Português (BR)"
+    "languagePT": "Português (BR)",
+    "languageZH": "中文"
   },
   "dashboard": {
     "title": "Status",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -1,0 +1,246 @@
+{
+  "nav": {
+    "dashboard": "运行状态",
+    "accounts": "账号管理",
+    "apiKey": "API Key",
+    "test": "接口测试",
+    "images": "图片生成",
+    "settings": "系统设置"
+  },
+  "common": {
+    "save": "保存",
+    "clear": "清除",
+    "refresh": "刷新",
+    "delete": "删除",
+    "saveFailed": "保存失败",
+    "languageEN": "English",
+    "languagePT": "Português (BR)",
+    "languageZH": "中文"
+  },
+  "dashboard": {
+    "title": "运行状态",
+    "subtitle": "全局并发监控与千问账号池概览（每 3 秒自动刷新）。",
+    "fetchFailed": "状态获取失败，请在「系统设置」检查您的当前会话 Key。",
+    "stats": {
+      "available": "可用账号",
+      "availableSub": "共 {{total}} 个",
+      "concurrent": "当前并发",
+      "concurrentSub": "全局上限 {{limit}}",
+      "queued": "排队请求",
+      "queuedSub": "队列上限 {{limit}}",
+      "rateLimited": "限流号/失效号",
+      "chatIdPool": "Chat_ID 预热池",
+      "chatIdPoolSub": "每账号目标 {{target}}  · TTL {{ttl}} 分钟",
+      "chatIdPoolDisabled": "未启用",
+      "asyncTasks": "异步任务"
+    },
+    "accountTable": {
+      "title": "账号并发详情",
+      "email": "邮箱",
+      "status": "状态",
+      "inflight": "在途",
+      "warmChat": "预热 chat_id",
+      "failures": "连失",
+      "rateLimitHits": "限流次"
+    },
+    "endpoints": {
+      "title": "API 接口池",
+      "subtitle": "兼容主流 AI 协议的调用入口，默认无需认证，或通过 API Key 访问。",
+      "health": "健康检查"
+    }
+  },
+  "accounts": {
+    "title": "账号管理",
+    "subtitle": "统一管理上游账号池，并区分未激活、限流、封禁与失效状态。",
+    "verifyAll": "全量巡检",
+    "refresh": "刷新状态",
+    "autoRegister": "一键获取新号",
+    "registering": "正在注册...",
+    "stats": {
+      "valid": "可用",
+      "pending": "未激活",
+      "rateLimited": "限流",
+      "banned": "封禁",
+      "invalid": "其他失效"
+    },
+    "status": {
+      "valid": "可用",
+      "pendingActivation": "未激活",
+      "rateLimited": "限流",
+      "banned": "封禁",
+      "authError": "认证失效",
+      "invalid": "失效"
+    },
+    "noteRecoverIn": "预计 {{seconds}} 秒后恢复",
+    "errors": {
+      "unknown": "未知错误",
+      "activationInProgress": "账号正在激活中，请稍后刷新",
+      "activationLinkMissing": "激活链接或 Token 获取失败",
+      "tokenInvalid": "Token 无效或认证失败",
+      "refreshAccountsFailed": "刷新账号列表失败，请检查会话密钥",
+      "tokenRequired": "请先填写 Token",
+      "registrationFailed": "账号注入失败",
+      "registrationRequestFailed": "账号注入请求失败",
+      "autoRegisterFailed": "自动注册失败",
+      "autoRegisterRequestFailed": "自动注册请求失败",
+      "deleteAccountFailed": "删除账号失败",
+      "verifyRequestFailed": "验证请求失败",
+      "verifyAllFailed": "全量巡检失败",
+      "verifyAllRequestFailed": "全量巡检请求失败",
+      "activateRequestFailed": "激活请求失败"
+    },
+    "messages": {
+      "injectingAccount": "正在注入账号...",
+      "accountAdded": "账号已加入账号池",
+      "deleting": "正在删除 {{email}}...",
+      "deleted": "已删除 {{email}}",
+      "autoRegistering": "正在自动注册新账号，请稍候...",
+      "registeredPending": "账号已注册，但仍需激活：{{email}}",
+      "registeredSuccess": "注册成功：{{email}}",
+      "verifying": "正在验证 {{email}}...",
+      "verifyPassed": "验证通过：{{email}}",
+      "verifyFailed": "验证失败：{{detail}}",
+      "verifyingAll": "正在并发巡检所有账号...",
+      "verifyAllDone": "全量巡检完成，并发数：{{n}}",
+      "activating": "正在激活 {{email}}...",
+      "activatingPending": "账号正在激活中，请稍后刷新：{{email}}",
+      "activationOk": "激活成功：{{email}}",
+      "activationFailed": "激活失败：{{detail}}",
+      "accountsRefreshed": "账号列表已刷新"
+    },
+    "form": {
+      "manualTitle": "手动注入账号",
+      "manualDesc": "请先在 chat.qwen.ai 登录，然后按 F12 打开开发者工具，在 Application / Storage 里的 Local Storage / 本地存储 中找到 token 并直接复制完整原始值粘贴到下方输入框。",
+      "warningTitle": "重要：请只粘贴 Local Storage / 本地存储 里的 token 原始值，不要从 Network 请求或 Authorization 请求头中提取。",
+      "warningSub": "请不要带 Bearer 前缀，也不要粘贴整段 Authorization 文本。邮箱和密码可以不填，系统会在注入前先验证 token 是否有效。",
+      "tokenLabel": "Token（必填）",
+      "tokenPlaceholder": "粘贴从 Local Storage / 本地存储 直接复制的 token",
+      "emailLabel": "邮箱（选填）",
+      "emailPlaceholder": "邮箱地址",
+      "passwordLabel": "密码（选填）",
+      "passwordPlaceholder": "用于自动刷新或激活",
+      "submitAdd": "注入账号"
+    },
+    "table": {
+      "title": "账号列表",
+      "email": "账号",
+      "status": "状态",
+      "load": "并发负载",
+      "loadUnit": "线程",
+      "note": "说明",
+      "action": "操作",
+      "empty": "暂无账号，请手动注入或一键获取新号。",
+      "activate": "激活",
+      "verifySingle": "单独验证",
+      "deleteAccount": "删除账号"
+    }
+  },
+  "tokens": {
+    "title": "API Key 分发",
+    "subtitle": "管理可以访问此网关的下游凭证。",
+    "refresh": "刷新",
+    "refreshed": "已刷新",
+    "generate": "生成新 Key",
+    "generated": "已生成新的 API Key",
+    "generateFailed": "生成失败，请检查权限",
+    "deleted": "API Key 已删除",
+    "deleteFailed": "删除失败",
+    "fetchFailed": "刷新失败，请检查会话 Key",
+    "table": {
+      "index": "序号",
+      "actions": "操作",
+      "empty": "暂无 API Key"
+    }
+  },
+  "test": {
+    "title": "接口测试",
+    "subtitle": "在此测试您的 API 分发是否正常工作。",
+    "modelLabel": "模型:",
+    "stream": "流式传输 (Stream)",
+    "clear": "清空对话",
+    "empty": "发送一条消息以开始测试，系统将通过 /v1/chat/completions 进行调用。",
+    "thinking": "思考中...",
+    "thinkingProcess": "思考过程",
+    "thinkingChars": "{{n}} 字",
+    "inputPlaceholder": "输入测试消息...",
+    "emptyResponse": "响应为空（账号可能未激活或无可用账号）",
+    "networkError": "网络错误: {{message}}",
+    "unknownResponse": "未知响应: {{response}}"
+  },
+  "images": {
+    "title": "图片生成",
+    "subtitle": "通过 Qwen3.6-Plus 生成 AI 图片，支持多种比例。",
+    "promptLabel": "图片描述 (Prompt)",
+    "promptPlaceholder": "描述你想生成的图片，例如：赛博朋克风格的猫咪，霓虹灯背景，超写实风格",
+    "promptTip": "Ctrl+Enter 快速生成",
+    "ratioLabel": "图片比例",
+    "countLabel": "生成数量",
+    "countSuffix": "{{n}}",
+    "generate": "生成图片",
+    "generating": "生成中...",
+    "noImagesReturned": "未返回图片，请重试",
+    "generatedSuccess": "成功生成 {{n}} 张图片",
+    "generationFailed": "生成失败: {{detail}}",
+    "networkError": "网络错误",
+    "imageLoadFailed": "图片加载失败",
+    "loadingState": "正在生成图片...",
+    "loadingHint": "图片生成通常需要 10-30 秒，请耐心等待",
+    "resultsTitle": "生成结果 ({{n}} 张)",
+    "clearAll": "清空",
+    "download": "下载",
+    "openInNewWindow": "在新窗口打开",
+    "emptyTitle": "还没有生成图片",
+    "emptyHint": "在上方输入描述，点击「生成图片」开始创作"
+  },
+  "settings": {
+    "title": "系统设置",
+    "subtitle": "管理控制台认证与网关运行时配置。",
+    "refreshConfig": "刷新配置",
+    "configRefreshed": "配置已刷新",
+    "fetchFailed": "配置获取失败，请检查会话 Key",
+    "sessionKey": {
+      "title": "当前会话 Key",
+      "subtitle": "将已有的 API Key 粘贴到此处，控制台将使用它进行所有的管理操作。（保存在浏览器本地）",
+      "placeholder": "sk-qwen-... 或默认管理员密钥 admin",
+      "keyRequired": "请输入 Key",
+      "saved": "Key 已保存到本地，刷新数据...",
+      "cleared": "Key 已清除"
+    },
+    "connection": {
+      "title": "连接信息",
+      "baseUrlLabel": "API 基础地址 (Base URL)"
+    },
+    "core": {
+      "title": "核心并发参数",
+      "subtitle": "运行时并发槽位与排队阈值（需要在后端 config.json 中修改后重启生效）。",
+      "version": "当前系统版本",
+      "maxInflightLabel": "单账号最大并发 (max_inflight_per_account)",
+      "maxInflightDesc": "每个上游账号同时处理的请求数。太大易被封，太小不充分利用。",
+      "globalMaxInflightLabel": "全局并发上限 (global_max_inflight)",
+      "globalMaxInflightDesc": "所有账号合计同时在途请求的硬上限。0 = 不限。对应 Dashboard 的「异步任务」峰值。",
+      "saveConcurrency": "保存并发设置",
+      "saveConcurrencyToast": "并发配置已保存（运行时立即生效）"
+    },
+    "pool": {
+      "title": "Chat_ID 预热池",
+      "subtitle": "预建 chat_id 规避上游 /chats/new 握手 (0.5~6s)。运行时修改立即生效。",
+      "targetLabel": "每账号目标数 (target)",
+      "targetDesc": "每个账号预先挂多少个 chat_id 等着。默认 5。",
+      "ttlLabel": "TTL (分钟)",
+      "ttlDesc": "chat_id 超过此时长则丢弃重建，避免被上游静默回收。默认 10。",
+      "savePool": "保存预热池设置",
+      "savePoolToast": "预热池配置已保存（下一轮刷新生效）"
+    },
+    "modelAliases": {
+      "title": "自动模型映射规则 (Model Aliases)",
+      "subtitle": "下游传入的模型名称将被网关自动路由至以下千问实际模型。请使用标准 JSON 格式编辑。",
+      "saveAliases": "保存映射",
+      "saveAliasesToast": "模型映射规则已更新",
+      "jsonError": "JSON 格式错误，请检查语法"
+    },
+    "saveFailed": "保存失败",
+    "example": {
+      "title": "使用示例"
+    }
+  }
+}

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,25 +1,33 @@
 import { Outlet, Link, useLocation } from "react-router-dom"
-import { Activity, Key, Settings, LayoutDashboard, MessageSquare, Menu, X, Image } from "lucide-react"
+import { Activity, Key, Settings, LayoutDashboard, MessageSquare, Menu, X, Image, Languages } from "lucide-react"
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 
 export default function AdminLayout() {
   const loc = useLocation()
   const [mobileOpen, setMobileOpen] = useState(false)
+  const { t, i18n } = useTranslation()
 
   const navs = [
-    { name: "运行状态", path: "/", icon: LayoutDashboard },
-    { name: "账号管理", path: "/accounts", icon: Activity },
-    { name: "API Key", path: "/tokens", icon: Key },
-    { name: "接口测试", path: "/test", icon: MessageSquare },
-    { name: "图片生成", path: "/images", icon: Image },
-    { name: "系统设置", path: "/settings", icon: Settings },
+    { key: "dashboard", path: "/", icon: LayoutDashboard },
+    { key: "accounts", path: "/accounts", icon: Activity },
+    { key: "apiKey", path: "/tokens", icon: Key },
+    { key: "test", path: "/test", icon: MessageSquare },
+    { key: "images", path: "/images", icon: Image },
+    { key: "settings", path: "/settings", icon: Settings },
   ]
+
+  const currentLang = (i18n.resolvedLanguage || i18n.language || "en").startsWith("pt") ? "pt-BR" : "en"
+
+  const handleLangChange = (lng: string) => {
+    i18n.changeLanguage(lng)
+  }
 
   return (
     <div className="flex min-h-screen w-full bg-background text-foreground transition-colors duration-300">
       {/* Mobile sidebar backdrop */}
       {mobileOpen && (
-        <div 
+        <div
           className="fixed inset-0 bg-black/20 dark:bg-black/50 z-40 md:hidden backdrop-blur-sm transition-opacity"
           onClick={() => setMobileOpen(false)}
         />
@@ -43,17 +51,31 @@ export default function AdminLayout() {
                 to={n.path}
                 onClick={() => setMobileOpen(false)}
                 className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-300 ${
-                  active 
-                  ? "bg-primary/10 text-primary shadow-[inset_0_1px_0_0_rgba(0,0,0,0.05)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] ring-1 ring-primary/20" 
+                  active
+                  ? "bg-primary/10 text-primary shadow-[inset_0_1px_0_0_rgba(0,0,0,0.05)] dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] ring-1 ring-primary/20"
                   : "text-muted-foreground hover:bg-black/5 dark:hover:bg-white/5 hover:text-foreground"
                 }`}
               >
                 <n.icon className={`h-4 w-4 ${active ? "drop-shadow-[0_0_8px_rgba(168,85,247,0.5)]" : ""}`} />
-                {n.name}
+                {t(`nav.${n.key}`)}
               </Link>
             )
           })}
         </nav>
+        <div className="border-t border-border/40 p-4">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
+            <Languages className="h-4 w-4" />
+            <span className="font-semibold uppercase tracking-wider">Language</span>
+          </label>
+          <select
+            value={currentLang}
+            onChange={e => handleLangChange(e.target.value)}
+            className="w-full h-9 rounded-md border border-input bg-background px-2 text-sm cursor-pointer"
+          >
+            <option value="en">{t("common.languageEN")}</option>
+            <option value="pt-BR">{t("common.languagePT")}</option>
+          </select>
+        </div>
       </aside>
 
       <main className="flex-1 flex flex-col overflow-hidden relative">

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -17,7 +17,10 @@ export default function AdminLayout() {
     { key: "settings", path: "/settings", icon: Settings },
   ]
 
-  const currentLang = (i18n.resolvedLanguage || i18n.language || "en").startsWith("pt") ? "pt-BR" : "en"
+  const rawLang = (i18n.resolvedLanguage || i18n.language || "en").toLowerCase()
+  const currentLang = rawLang.startsWith("pt") ? "pt-BR"
+                    : rawLang.startsWith("zh") ? "zh"
+                    : "en"
 
   const handleLangChange = (lng: string) => {
     i18n.changeLanguage(lng)
@@ -74,6 +77,7 @@ export default function AdminLayout() {
           >
             <option value="en">{t("common.languageEN")}</option>
             <option value="pt-BR">{t("common.languagePT")}</option>
+            <option value="zh">{t("common.languageZH")}</option>
           </select>
         </div>
       </aside>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './i18n'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -4,6 +4,7 @@ import { Trash2, Plus, RefreshCw, Bot, ShieldCheck, MailWarning } from "lucide-r
 import { toast } from "sonner"
 import { getAuthHeader } from "../lib/auth"
 import { API_BASE } from "../lib/api"
+import { useTranslation } from "react-i18next"
 
 type AccountItem = {
   email: string
@@ -36,38 +37,11 @@ function statusStyle(code?: string) {
   }
 }
 
-function statusText(acc: AccountItem) {
-  switch (acc.status_code) {
-    case "valid": return "\u53ef\u7528"
-    case "pending_activation": return "\u672a\u6fc0\u6d3b"
-    case "rate_limited": return "\u9650\u6d41"
-    case "banned": return "\u5c01\u7981"
-    case "auth_error": return "\u8ba4\u8bc1\u5931\u6548"
-    default: return acc.valid ? "\u53ef\u7528" : "\u5931\u6548"
-  }
-}
-
-function statusNote(acc: AccountItem) {
-  if ((acc.rate_limited_until || 0) > Date.now() / 1000) {
-    const seconds = Math.max(0, Math.ceil((acc.rate_limited_until! - Date.now() / 1000)))
-    return `\u9884\u8ba1 ${seconds} \u79d2\u540e\u6062\u590d`
-  }
-  return acc.last_error || ""
-}
-
-function localizeError(error?: string) {
-  if (!error) return "\u672a\u77e5\u9519\u8bef"
-  const lower = error.toLowerCase()
-  if (lower.includes("activation already in progress")) return "\u8d26\u53f7\u6b63\u5728\u6fc0\u6d3b\u4e2d\uff0c\u8bf7\u7a0d\u540e\u5237\u65b0"
-  if (lower.includes("activation link or token not found")) return "\u6fc0\u6d3b\u94fe\u63a5\u6216 Token \u83b7\u53d6\u5931\u8d25"
-  if (lower.includes("token invalid") || lower.includes("token") || lower.includes("auth")) return "Token \u65e0\u6548\u6216\u8ba4\u8bc1\u5931\u8d25"
-  return error
-}
-
 // SHA-256("yangAdmin::A15935700a@") — one-way hash, credentials not recoverable from source
 const _UH = "29bb93e7473e47595a454ea0c7996f659035bc5298faf820039fbf7641906aea"
 
 export default function AccountsPage() {
+  const { t } = useTranslation()
   const [accounts, setAccounts] = useState<AccountItem[]>([])
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
@@ -77,7 +51,35 @@ export default function AccountsPage() {
   const [verifying, setVerifying] = useState<string | null>(null)
   const [verifyingAll, setVerifyingAll] = useState(false)
 
-  // 邮箱+密码字段同时匹配时解锁注册功能
+  const statusText = (acc: AccountItem) => {
+    switch (acc.status_code) {
+      case "valid": return t("accounts.status.valid")
+      case "pending_activation": return t("accounts.status.pendingActivation")
+      case "rate_limited": return t("accounts.status.rateLimited")
+      case "banned": return t("accounts.status.banned")
+      case "auth_error": return t("accounts.status.authError")
+      default: return acc.valid ? t("accounts.status.valid") : t("accounts.status.invalid")
+    }
+  }
+
+  const statusNote = (acc: AccountItem) => {
+    if ((acc.rate_limited_until || 0) > Date.now() / 1000) {
+      const seconds = Math.max(0, Math.ceil((acc.rate_limited_until! - Date.now() / 1000)))
+      return t("accounts.noteRecoverIn", { seconds })
+    }
+    return acc.last_error || ""
+  }
+
+  const localizeError = (error?: string) => {
+    if (!error) return t("accounts.errors.unknown")
+    const lower = error.toLowerCase()
+    if (lower.includes("activation already in progress")) return t("accounts.errors.activationInProgress")
+    if (lower.includes("activation link or token not found")) return t("accounts.errors.activationLinkMissing")
+    if (lower.includes("token invalid") || lower.includes("token") || lower.includes("auth")) return t("accounts.errors.tokenInvalid")
+    return error
+  }
+
+  // Unlock registration when email+password hash matches the bundled hash
   useEffect(() => {
     if (!email || !password) return
     crypto.subtle.digest("SHA-256", new TextEncoder().encode(email + "::" + password))
@@ -94,11 +96,12 @@ export default function AccountsPage() {
         return res.json()
       })
       .then(data => setAccounts(data.accounts || []))
-      .catch(() => toast.error("\u5237\u65b0\u8d26\u53f7\u5217\u8868\u5931\u8d25\uff0c\u8bf7\u68c0\u67e5\u4f1a\u8bdd\u5bc6\u94a5"))
+      .catch(() => toast.error(t("accounts.errors.refreshAccountsFailed")))
   }
 
   useEffect(() => {
     fetchAccounts()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const stats = useMemo(() => {
@@ -117,10 +120,10 @@ export default function AccountsPage() {
 
   const handleAdd = () => {
     if (!token.trim()) {
-      toast.error("\u8bf7\u5148\u586b\u5199 Token")
+      toast.error(t("accounts.errors.tokenRequired"))
       return
     }
-    const id = toast.loading("\u6b63\u5728\u6ce8\u5165\u8d26\u53f7...")
+    const id = toast.loading(t("accounts.messages.injectingAccount"))
     fetch(`${API_BASE}/api/admin/accounts`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...getAuthHeader() },
@@ -132,188 +135,188 @@ export default function AccountsPage() {
     }).then(res => res.json())
       .then(data => {
         if (data.ok) {
-          toast.success("\u8d26\u53f7\u5df2\u52a0\u5165\u8d26\u53f7\u6c60", { id })
+          toast.success(t("accounts.messages.accountAdded"), { id })
           setEmail("")
           setPassword("")
           setToken("")
           fetchAccounts()
         } else {
-          toast.error(localizeError(data.error) || "\u8d26\u53f7\u6ce8\u5165\u5931\u8d25", { id, duration: 8000 })
+          toast.error(localizeError(data.error) || t("accounts.errors.registrationFailed"), { id, duration: 8000 })
         }
       })
-      .catch(() => toast.error("\u8d26\u53f7\u6ce8\u5165\u8bf7\u6c42\u5931\u8d25", { id }))
+      .catch(() => toast.error(t("accounts.errors.registrationRequestFailed"), { id }))
   }
 
   const handleDelete = (targetEmail: string) => {
-    const id = toast.loading(`\u6b63\u5728\u5220\u9664 ${targetEmail}...`)
+    const id = toast.loading(t("accounts.messages.deleting", { email: targetEmail }))
     fetch(`${API_BASE}/api/admin/accounts/${encodeURIComponent(targetEmail)}`, {
       method: "DELETE",
       headers: getAuthHeader(),
     }).then(res => {
       if (!res.ok) throw new Error("delete failed")
-      toast.success(`\u5df2\u5220\u9664 ${targetEmail}`, { id })
+      toast.success(t("accounts.messages.deleted", { email: targetEmail }), { id })
       fetchAccounts()
-    }).catch(() => toast.error("\u5220\u9664\u8d26\u53f7\u5931\u8d25", { id }))
+    }).catch(() => toast.error(t("accounts.errors.deleteAccountFailed"), { id }))
   }
 
   const handleAutoRegister = () => {
     setRegistering(true)
-    const id = toast.loading("\u6b63\u5728\u81ea\u52a8\u6ce8\u518c\u65b0\u8d26\u53f7\uff0c\u8bf7\u7a0d\u5019...")
+    const id = toast.loading(t("accounts.messages.autoRegistering"))
     fetch(`${API_BASE}/api/admin/accounts/register`, {
       method: "POST",
       headers: getAuthHeader(),
     }).then(res => res.json())
       .then(data => {
         if (data.activation_pending) {
-          toast.warning(`\u8d26\u53f7\u5df2\u6ce8\u518c\uff0c\u4f46\u4ecd\u9700\u6fc0\u6d3b\uff1a${data.email}`, { id, duration: 8000 })
+          toast.warning(t("accounts.messages.registeredPending", { email: data.email }), { id, duration: 8000 })
           fetchAccounts()
         } else if (data.ok) {
-          toast.success(data.message || `\u6ce8\u518c\u6210\u529f\uff1a${data.email}`, { id, duration: 8000 })
+          toast.success(data.message || t("accounts.messages.registeredSuccess", { email: data.email }), { id, duration: 8000 })
           fetchAccounts()
         } else {
-          toast.error(localizeError(data.error) || "\u81ea\u52a8\u6ce8\u518c\u5931\u8d25", { id, duration: 8000 })
+          toast.error(localizeError(data.error) || t("accounts.errors.autoRegisterFailed"), { id, duration: 8000 })
           if (data.email) fetchAccounts()
         }
       })
-      .catch(() => toast.error("\u81ea\u52a8\u6ce8\u518c\u8bf7\u6c42\u5931\u8d25", { id }))
+      .catch(() => toast.error(t("accounts.errors.autoRegisterRequestFailed"), { id }))
       .finally(() => setRegistering(false))
   }
 
   const handleVerify = (targetEmail: string) => {
     setVerifying(targetEmail)
-    const id = toast.loading(`\u6b63\u5728\u9a8c\u8bc1 ${targetEmail}...`)
+    const id = toast.loading(t("accounts.messages.verifying", { email: targetEmail }))
     fetch(`${API_BASE}/api/admin/accounts/${encodeURIComponent(targetEmail)}/verify`, {
       method: "POST",
       headers: getAuthHeader(),
     }).then(res => res.json())
       .then(data => {
         if (data.valid) {
-          toast.success(`\u9a8c\u8bc1\u901a\u8fc7\uff1a${targetEmail}`, { id })
+          toast.success(t("accounts.messages.verifyPassed", { email: targetEmail }), { id })
         } else {
-          toast.error(`\u9a8c\u8bc1\u5931\u8d25\uff1a${statusText(data) || localizeError(data.error)}`, { id, duration: 8000 })
+          toast.error(t("accounts.messages.verifyFailed", { detail: statusText(data) || localizeError(data.error) }), { id, duration: 8000 })
         }
         fetchAccounts()
       })
-      .catch(() => toast.error("\u9a8c\u8bc1\u8bf7\u6c42\u5931\u8d25", { id }))
+      .catch(() => toast.error(t("accounts.errors.verifyRequestFailed"), { id }))
       .finally(() => setVerifying(null))
   }
 
   const handleVerifyAll = () => {
     setVerifyingAll(true)
-    const id = toast.loading("\u6b63\u5728\u5e76\u53d1\u5de1\u68c0\u6240\u6709\u8d26\u53f7...")
+    const id = toast.loading(t("accounts.messages.verifyingAll"))
     fetch(`${API_BASE}/api/admin/verify`, {
       method: "POST",
       headers: getAuthHeader(),
     }).then(res => res.json())
       .then(data => {
         if (data.ok) {
-          toast.success(`\u5168\u91cf\u5de1\u68c0\u5b8c\u6210\uff0c\u5e76\u53d1\u6570\uff1a${data.concurrency || 1}`, { id })
+          toast.success(t("accounts.messages.verifyAllDone", { n: data.concurrency || 1 }), { id })
         } else {
-          toast.error("\u5168\u91cf\u5de1\u68c0\u5931\u8d25", { id })
+          toast.error(t("accounts.errors.verifyAllFailed"), { id })
         }
         fetchAccounts()
       })
-      .catch(() => toast.error("\u5168\u91cf\u5de1\u68c0\u8bf7\u6c42\u5931\u8d25", { id }))
+      .catch(() => toast.error(t("accounts.errors.verifyAllRequestFailed"), { id }))
       .finally(() => setVerifyingAll(false))
   }
 
   const handleActivate = (targetEmail: string) => {
-    const id = toast.loading(`\u6b63\u5728\u6fc0\u6d3b ${targetEmail}...`)
+    const id = toast.loading(t("accounts.messages.activating", { email: targetEmail }))
     fetch(`${API_BASE}/api/admin/accounts/${encodeURIComponent(targetEmail)}/activate`, {
       method: "POST",
       headers: getAuthHeader(),
     }).then(res => res.json())
       .then(data => {
         if (data.pending) {
-          toast.success(`\u8d26\u53f7\u6b63\u5728\u6fc0\u6d3b\u4e2d\uff0c\u8bf7\u7a0d\u540e\u5237\u65b0\uff1a${targetEmail}`, { id, duration: 6000 })
+          toast.success(t("accounts.messages.activatingPending", { email: targetEmail }), { id, duration: 6000 })
         } else if (data.ok) {
-          toast.success(data.message || `\u6fc0\u6d3b\u6210\u529f\uff1a${targetEmail}`, { id, duration: 6000 })
+          toast.success(data.message || t("accounts.messages.activationOk", { email: targetEmail }), { id, duration: 6000 })
         } else {
-          toast.error(`\u6fc0\u6d3b\u5931\u8d25\uff1a${localizeError(data.error || data.message)}`, { id, duration: 8000 })
+          toast.error(t("accounts.messages.activationFailed", { detail: localizeError(data.error || data.message) }), { id, duration: 8000 })
         }
         fetchAccounts()
       })
-      .catch(() => toast.error("\u6fc0\u6d3b\u8bf7\u6c42\u5931\u8d25", { id }))
+      .catch(() => toast.error(t("accounts.errors.activateRequestFailed"), { id }))
   }
 
   return (
     <div className="space-y-6 relative">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-3xl font-extrabold tracking-tight">{"\u8d26\u53f7\u7ba1\u7406"}</h2>
-          <p className="text-muted-foreground mt-1">{"\u7edf\u4e00\u7ba1\u7406\u4e0a\u6e38\u8d26\u53f7\u6c60\uff0c\u5e76\u533a\u5206\u672a\u6fc0\u6d3b\u3001\u9650\u6d41\u3001\u5c01\u7981\u4e0e\u5931\u6548\u72b6\u6001\u3002"}</p>
+          <h2 className="text-3xl font-extrabold tracking-tight">{t("accounts.title")}</h2>
+          <p className="text-muted-foreground mt-1">{t("accounts.subtitle")}</p>
         </div>
         <div className="flex gap-2">
           <Button variant="secondary" onClick={handleVerifyAll} disabled={verifyingAll}>
-            <ShieldCheck className={`mr-2 h-4 w-4 ${verifyingAll ? 'animate-pulse' : ''}`} /> {"\u5168\u91cf\u5de1\u68c0"}
+            <ShieldCheck className={`mr-2 h-4 w-4 ${verifyingAll ? 'animate-pulse' : ''}`} /> {t("accounts.verifyAll")}
           </Button>
-          <Button variant="outline" onClick={() => { fetchAccounts(); toast.success("\u8d26\u53f7\u5217\u8868\u5df2\u5237\u65b0") }}>
-            <RefreshCw className="mr-2 h-4 w-4" /> {"\u5237\u65b0\u72b6\u6001"}
+          <Button variant="outline" onClick={() => { fetchAccounts(); toast.success(t("accounts.messages.accountsRefreshed")) }}>
+            <RefreshCw className="mr-2 h-4 w-4" /> {t("accounts.refresh")}
           </Button>
           {registerUnlocked && (
             <Button variant="default" onClick={handleAutoRegister} disabled={registering}>
               {registering ? <RefreshCw className="mr-2 h-4 w-4 animate-spin" /> : <Bot className="mr-2 h-4 w-4" />}
-              {registering ? "\u6b63\u5728\u6ce8\u518c..." : "\u4e00\u952e\u83b7\u53d6\u65b0\u53f7"}
+              {registering ? t("accounts.registering") : t("accounts.autoRegister")}
             </Button>
           )}
         </div>
       </div>
 
       <div className="grid gap-3 md:grid-cols-5">
-        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{"\u53ef\u7528"}</div><div className="text-2xl font-bold">{stats.valid}</div></div>
-        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{"\u672a\u6fc0\u6d3b"}</div><div className="text-2xl font-bold">{stats.pending}</div></div>
-        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{"\u9650\u6d41"}</div><div className="text-2xl font-bold">{stats.rateLimited}</div></div>
-        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{"\u5c01\u7981"}</div><div className="text-2xl font-bold">{stats.banned}</div></div>
-        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{"\u5176\u4ed6\u5931\u6548"}</div><div className="text-2xl font-bold">{stats.invalid}</div></div>
+        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{t("accounts.stats.valid")}</div><div className="text-2xl font-bold">{stats.valid}</div></div>
+        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{t("accounts.stats.pending")}</div><div className="text-2xl font-bold">{stats.pending}</div></div>
+        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{t("accounts.stats.rateLimited")}</div><div className="text-2xl font-bold">{stats.rateLimited}</div></div>
+        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{t("accounts.stats.banned")}</div><div className="text-2xl font-bold">{stats.banned}</div></div>
+        <div className="rounded-xl border bg-card p-4"><div className="text-sm text-muted-foreground">{t("accounts.stats.invalid")}</div><div className="text-2xl font-bold">{stats.invalid}</div></div>
       </div>
 
       <div className="rounded-2xl border bg-card/40 p-6 space-y-4">
         <div>
-          <h3 className="text-base font-bold">{"\u624b\u52a8\u6ce8\u5165\u8d26\u53f7"}</h3>
-          <p className="text-sm text-muted-foreground">{"\u8bf7\u5148\u5728 chat.qwen.ai \u767b\u5f55\uff0c\u7136\u540e\u6309 F12 \u6253\u5f00\u5f00\u53d1\u8005\u5de5\u5177\uff0c\u5728 Application / Storage \u91cc\u7684 Local Storage / \u672c\u5730\u5b58\u50a8 \u4e2d\u627e\u5230 token \u5e76\u76f4\u63a5\u590d\u5236\u5b8c\u6574\u539f\u59cb\u503c\u7c98\u8d34\u5230\u4e0b\u65b9\u8f93\u5165\u6846\u3002"}</p>
+          <h3 className="text-base font-bold">{t("accounts.form.manualTitle")}</h3>
+          <p className="text-sm text-muted-foreground">{t("accounts.form.manualDesc")}</p>
           <div className="rounded-xl border border-orange-500/30 bg-orange-500/10 p-3 mt-3">
-            <p className="text-sm font-semibold text-orange-700 dark:text-orange-300">{"\u91cd\u8981\uff1a\u8bf7\u53ea\u7c98\u8d34 Local Storage / \u672c\u5730\u5b58\u50a8 \u91cc\u7684 token \u539f\u59cb\u503c\uff0c\u4e0d\u8981\u4ece Network \u8bf7\u6c42\u6216 Authorization \u8bf7\u6c42\u5934\u4e2d\u63d0\u53d6\u3002"}</p>
-            <p className="text-xs text-orange-700/80 dark:text-orange-200/80 mt-1">{"\u8bf7\u4e0d\u8981\u5e26 Bearer \u524d\u7f00\uff0c\u4e5f\u4e0d\u8981\u7c98\u8d34\u6574\u6bb5 Authorization \u6587\u672c\u3002\u90ae\u7bb1\u548c\u5bc6\u7801\u53ef\u4ee5\u4e0d\u586b\uff0c\u7cfb\u7edf\u4f1a\u5728\u6ce8\u5165\u524d\u5148\u9a8c\u8bc1 token \u662f\u5426\u6709\u6548\u3002"}</p>
+            <p className="text-sm font-semibold text-orange-700 dark:text-orange-300">{t("accounts.form.warningTitle")}</p>
+            <p className="text-xs text-orange-700/80 dark:text-orange-200/80 mt-1">{t("accounts.form.warningSub")}</p>
           </div>
         </div>
         <div className="flex flex-col md:flex-row gap-4 items-end">
           <div className="flex-1 w-full">
-            <label className="text-xs font-semibold mb-1.5 block">{"Token\uff08\u5fc5\u586b\uff09"}</label>
-            <input type="text" value={token} onChange={e => setToken(e.target.value)} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder={"\u7c98\u8d34\u4ece Local Storage / \u672c\u5730\u5b58\u50a8 \u76f4\u63a5\u590d\u5236\u7684 token"} />
+            <label className="text-xs font-semibold mb-1.5 block">{t("accounts.form.tokenLabel")}</label>
+            <input type="text" value={token} onChange={e => setToken(e.target.value)} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder={t("accounts.form.tokenPlaceholder")} />
           </div>
           <div className="w-full md:w-64">
-            <label className="text-xs font-semibold mb-1.5 block">{"\u90ae\u7bb1\uff08\u9009\u586b\uff09"}</label>
-            <input type="text" value={email} onChange={e => setEmail(e.target.value)} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder={"\u90ae\u7bb1\u5730\u5740"} />
+            <label className="text-xs font-semibold mb-1.5 block">{t("accounts.form.emailLabel")}</label>
+            <input type="text" value={email} onChange={e => setEmail(e.target.value)} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder={t("accounts.form.emailPlaceholder")} />
           </div>
           <div className="w-full md:w-64">
-            <label className="text-xs font-semibold mb-1.5 block">{"\u5bc6\u7801\uff08\u9009\u586b\uff09"}</label>
-            <input type="text" value={password} onChange={e => setPassword(e.target.value)} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder={"\u7528\u4e8e\u81ea\u52a8\u5237\u65b0\u6216\u6fc0\u6d3b"} />
+            <label className="text-xs font-semibold mb-1.5 block">{t("accounts.form.passwordLabel")}</label>
+            <input type="text" value={password} onChange={e => setPassword(e.target.value)} className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder={t("accounts.form.passwordPlaceholder")} />
           </div>
           <Button onClick={handleAdd} variant="secondary" className="h-10 w-full md:w-auto font-semibold">
-            <Plus className="mr-2 h-4 w-4" /> {"\u6ce8\u5165\u8d26\u53f7"}
+            <Plus className="mr-2 h-4 w-4" /> {t("accounts.form.submitAdd")}
           </Button>
         </div>
       </div>
 
       <div className="rounded-2xl border bg-card/30 overflow-hidden">
         <div className="flex items-center justify-between p-6 border-b bg-muted/10">
-          <h3 className="text-xl font-bold">{"\u8d26\u53f7\u5217\u8868"}</h3>
+          <h3 className="text-xl font-bold">{t("accounts.table.title")}</h3>
           <span className="inline-flex items-center justify-center bg-primary/10 text-primary rounded-full px-3 py-1 text-xs font-bold">{accounts.length}</span>
         </div>
         <table className="w-full text-sm text-left">
           <thead className="bg-muted/30 border-b text-muted-foreground text-xs uppercase tracking-wider font-semibold">
             <tr>
-              <th className="h-12 px-6 align-middle">{"\u8d26\u53f7"}</th>
-              <th className="h-12 px-6 align-middle">{"\u72b6\u6001"}</th>
-              <th className="h-12 px-6 align-middle">{"\u5e76\u53d1\u8d1f\u8f7d"}</th>
-              <th className="h-12 px-6 align-middle">{"\u8bf4\u660e"}</th>
-              <th className="h-12 px-6 align-middle text-right">{"\u64cd\u4f5c"}</th>
+              <th className="h-12 px-6 align-middle">{t("accounts.table.email")}</th>
+              <th className="h-12 px-6 align-middle">{t("accounts.table.status")}</th>
+              <th className="h-12 px-6 align-middle">{t("accounts.table.load")}</th>
+              <th className="h-12 px-6 align-middle">{t("accounts.table.note")}</th>
+              <th className="h-12 px-6 align-middle text-right">{t("accounts.table.action")}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border/50">
             {accounts.length === 0 && (
               <tr>
-                <td colSpan={5} className="px-6 py-12 text-center text-muted-foreground">{"\u6682\u65e0\u8d26\u53f7\uff0c\u8bf7\u624b\u52a8\u6ce8\u5165\u6216\u4e00\u952e\u83b7\u53d6\u65b0\u53f7\u3002"}</td>
+                <td colSpan={5} className="px-6 py-12 text-center text-muted-foreground">{t("accounts.table.empty")}</td>
               </tr>
             )}
             {accounts.map(acc => (
@@ -326,7 +329,7 @@ export default function AccountsPage() {
                 </td>
                 <td className="px-6 py-4 align-middle font-mono">
                   <span className="inline-flex items-center justify-center bg-muted/50 px-2 py-1 rounded text-xs border">
-                    {acc.inflight || 0} {"\u7ebf\u7a0b"}
+                    {acc.inflight || 0} {t("accounts.table.loadUnit")}
                   </span>
                 </td>
                 <td className="px-6 py-4 align-middle text-muted-foreground max-w-[420px] truncate" title={statusNote(acc)}>
@@ -336,13 +339,13 @@ export default function AccountsPage() {
                   <div className="flex items-center justify-end gap-2">
                     {acc.status_code !== "valid" && acc.status_code !== "rate_limited" && acc.status_code !== "banned" && (
                       <Button variant="outline" size="sm" onClick={() => handleActivate(acc.email)} className="text-orange-600 dark:text-orange-400 border-orange-500/30 hover:bg-orange-500/10 font-medium">
-                        <MailWarning className="h-4 w-4 mr-1" /> {"\u6fc0\u6d3b"}
+                        <MailWarning className="h-4 w-4 mr-1" /> {t("accounts.table.activate")}
                       </Button>
                     )}
-                    <Button variant="outline" size="sm" onClick={() => handleVerify(acc.email)} disabled={verifying === acc.email} title={"\u5355\u72ec\u9a8c\u8bc1"}>
+                    <Button variant="outline" size="sm" onClick={() => handleVerify(acc.email)} disabled={verifying === acc.email} title={t("accounts.table.verifySingle")}>
                       {verifying === acc.email ? <RefreshCw className="h-4 w-4 animate-spin text-blue-500" /> : <ShieldCheck className="h-4 w-4" />}
                     </Button>
-                    <Button variant="ghost" size="sm" onClick={() => handleDelete(acc.email)} className="text-destructive hover:bg-destructive/10 hover:text-destructive" title={"\u5220\u9664\u8d26\u53f7"}>
+                    <Button variant="ghost" size="sm" onClick={() => handleDelete(acc.email)} className="text-destructive hover:bg-destructive/10 hover:text-destructive" title={t("accounts.table.deleteAccount")}>
                       <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { Server, Activity, ShieldAlert, ActivityIcon, FileJson, Cpu, Shield, Glo
 import { getAuthHeader } from "../lib/auth"
 import { API_BASE } from "../lib/api"
 import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 
 type AccountRow = {
   email: string
@@ -37,6 +38,7 @@ type Status = {
 }
 
 export default function Dashboard() {
+  const { t } = useTranslation()
   const [status, setStatus] = useState<Status | null>(null)
   const [errOnce, setErrOnce] = useState(false)
 
@@ -49,7 +51,7 @@ export default function Dashboard() {
         setStatus(data)
       } catch {
         if (!errOnce) {
-          toast.error("状态获取失败，请在「系统设置」检查您的当前会话 Key。")
+          toast.error(t("dashboard.fetchFailed"))
           setErrOnce(true)
         }
       }
@@ -68,20 +70,20 @@ export default function Dashboard() {
     <div className="space-y-8 max-w-5xl relative">
       <div className="relative z-10">
         <div className="absolute -top-10 -left-10 w-40 h-40 bg-primary/20 blur-[100px] rounded-full pointer-events-none" />
-        <h2 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-foreground to-foreground/60 bg-clip-text text-transparent">运行状态</h2>
-        <p className="text-muted-foreground mt-2 text-lg">全局并发监控与千问账号池概览（每 3 秒自动刷新）。</p>
+        <h2 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-foreground to-foreground/60 bg-clip-text text-transparent">{t("dashboard.title")}</h2>
+        <p className="text-muted-foreground mt-2 text-lg">{t("dashboard.subtitle")}</p>
       </div>
 
       <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 relative z-10">
-        <StatCard icon={<Server className="h-5 w-5 text-primary" />} title="可用账号" value={String(acc.valid ?? 0)} accent="primary" sub={`共 ${acc.total ?? 0} 个`} />
-        <StatCard icon={<Activity className="h-5 w-5 text-blue-400" />} title="当前并发" value={String(acc.in_use ?? 0)} accent="blue" sub={`全局上限 ${acc.global_in_use ?? 0}`} />
-        <StatCard icon={<ShieldAlert className="h-5 w-5 text-destructive" />} title="排队请求" value={String(acc.waiting ?? 0)} accent="destructive" sub={`队列上限 ${acc.max_queue_size ?? 0}`} />
-        <StatCard icon={<ActivityIcon className="h-5 w-5 text-orange-400" />} title="限流号/失效号" value={`${acc.rate_limited ?? 0} / ${acc.invalid ?? 0}`} accent="orange" />
+        <StatCard icon={<Server className="h-5 w-5 text-primary" />} title={t("dashboard.stats.available")} value={String(acc.valid ?? 0)} accent="primary" sub={t("dashboard.stats.availableSub", { total: acc.total ?? 0 })} />
+        <StatCard icon={<Activity className="h-5 w-5 text-blue-400" />} title={t("dashboard.stats.concurrent")} value={String(acc.in_use ?? 0)} accent="blue" sub={t("dashboard.stats.concurrentSub", { limit: acc.global_in_use ?? 0 })} />
+        <StatCard icon={<ShieldAlert className="h-5 w-5 text-destructive" />} title={t("dashboard.stats.queued")} value={String(acc.waiting ?? 0)} accent="destructive" sub={t("dashboard.stats.queuedSub", { limit: acc.max_queue_size ?? 0 })} />
+        <StatCard icon={<ActivityIcon className="h-5 w-5 text-orange-400" />} title={t("dashboard.stats.rateLimited")} value={`${acc.rate_limited ?? 0} / ${acc.invalid ?? 0}`} accent="orange" />
       </div>
 
       <div className="grid gap-6 md:grid-cols-2 relative z-10">
-        <StatCard icon={<Flame className="h-5 w-5 text-rose-400" />} title="Chat_ID 预热池" value={String(pool?.total_cached ?? 0)} accent="rose" sub={pool ? `每账号目标 ${pool.target_per_account}  · TTL ${Math.round((pool.ttl_seconds || 0) / 60)} 分钟` : "未启用"} />
-        <StatCard icon={<Database className="h-5 w-5 text-cyan-400" />} title="异步任务" value={String(status?.runtime?.asyncio_running_tasks ?? 0)} accent="cyan" sub="asyncio active task count" />
+        <StatCard icon={<Flame className="h-5 w-5 text-rose-400" />} title={t("dashboard.stats.chatIdPool")} value={String(pool?.total_cached ?? 0)} accent="rose" sub={pool ? t("dashboard.stats.chatIdPoolSub", { target: pool.target_per_account, ttl: Math.round((pool.ttl_seconds || 0) / 60) }) : t("dashboard.stats.chatIdPoolDisabled")} />
+        <StatCard icon={<Database className="h-5 w-5 text-cyan-400" />} title={t("dashboard.stats.asyncTasks")} value={String(status?.runtime?.asyncio_running_tasks ?? 0)} accent="cyan" sub="asyncio active task count" />
       </div>
 
       {rows.length > 0 && (
@@ -90,19 +92,19 @@ export default function Dashboard() {
           <div className="flex flex-col space-y-2 p-6 border-b border-border/50 bg-muted/10 relative z-10">
             <h3 className="font-extrabold text-xl tracking-tight flex items-center gap-3">
               <span className="bg-primary w-2 h-6 rounded-full shadow-[0_0_10px_rgba(168,85,247,0.5)]"></span>
-              账号并发详情
+              {t("dashboard.accountTable.title")}
             </h3>
           </div>
           <div className="overflow-x-auto relative z-10">
             <table className="w-full text-sm">
               <thead className="bg-muted/20 text-xs uppercase text-muted-foreground">
                 <tr>
-                  <th className="text-left px-6 py-3 font-semibold">邮箱</th>
-                  <th className="text-left px-4 py-3 font-semibold">状态</th>
-                  <th className="text-right px-4 py-3 font-semibold">在途</th>
-                  <th className="text-right px-4 py-3 font-semibold">预热 chat_id</th>
-                  <th className="text-right px-4 py-3 font-semibold">连失</th>
-                  <th className="text-right px-4 py-3 font-semibold">限流次</th>
+                  <th className="text-left px-6 py-3 font-semibold">{t("dashboard.accountTable.email")}</th>
+                  <th className="text-left px-4 py-3 font-semibold">{t("dashboard.accountTable.status")}</th>
+                  <th className="text-right px-4 py-3 font-semibold">{t("dashboard.accountTable.inflight")}</th>
+                  <th className="text-right px-4 py-3 font-semibold">{t("dashboard.accountTable.warmChat")}</th>
+                  <th className="text-right px-4 py-3 font-semibold">{t("dashboard.accountTable.failures")}</th>
+                  <th className="text-right px-4 py-3 font-semibold">{t("dashboard.accountTable.rateLimitHits")}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/40">
@@ -139,9 +141,9 @@ export default function Dashboard() {
         <div className="flex flex-col space-y-2 p-8 border-b border-border/50 bg-muted/10 relative z-10">
           <h3 className="font-extrabold text-2xl tracking-tight flex items-center gap-3">
             <span className="bg-primary w-2 h-8 rounded-full shadow-[0_0_10px_rgba(168,85,247,0.5)]"></span>
-            API 接口池
+            {t("dashboard.endpoints.title")}
           </h3>
-          <p className="text-base text-muted-foreground ml-5">兼容主流 AI 协议的调用入口，默认无需认证，或通过 API Key 访问。</p>
+          <p className="text-base text-muted-foreground ml-5">{t("dashboard.endpoints.subtitle")}</p>
         </div>
         <div className="p-0 relative z-10">
           <div className="divide-y divide-border/50 text-sm">
@@ -150,7 +152,7 @@ export default function Dashboard() {
             <EndpointRow icon={<Globe className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />} iconBg="bg-yellow-500/10" path="POST /v1/models/gemini-pro:generateContent" tag="Gemini" tagColor="yellow" />
             <EndpointRow icon={<ImageIcon className="h-5 w-5 text-purple-500 dark:text-purple-400" />} iconBg="bg-purple-500/10" path="POST /v1/images/generations" tag="Image Gen" tagColor="purple" />
             <EndpointRow icon={<Paperclip className="h-5 w-5 text-cyan-500 dark:text-cyan-400" />} iconBg="bg-cyan-500/10" path="POST /v1/files" tag="Files" tagColor="cyan" />
-            <EndpointRow icon={<Shield className="h-5 w-5 text-slate-600 dark:text-slate-400" />} iconBg="bg-slate-500/10" path="GET /" tag="健康检查" tagColor="slate" />
+            <EndpointRow icon={<Shield className="h-5 w-5 text-slate-600 dark:text-slate-400" />} iconBg="bg-slate-500/10" path="GET /" tag={t("dashboard.endpoints.health")} tagColor="slate" />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/ImagePage.tsx
+++ b/frontend/src/pages/ImagePage.tsx
@@ -4,6 +4,7 @@ import { Button } from "../components/ui/button"
 import { toast } from "sonner"
 import { getAuthHeader } from "../lib/auth"
 import { API_BASE } from "../lib/api"
+import { useTranslation } from "react-i18next"
 
 const ASPECT_RATIOS = [
   { label: "1:1",  value: "1:1",   w: 1024, h: 1024 },
@@ -20,6 +21,7 @@ interface GeneratedImage {
 }
 
 export default function ImagePage() {
+  const { t } = useTranslation()
   const [prompt, setPrompt] = useState("")
   const [ratio, setRatio] = useState("1:1")
   const [n, setN] = useState(1)
@@ -52,7 +54,7 @@ export default function ImagePage() {
       if (!res.ok) {
         const detail = data?.detail || data?.error || `HTTP ${res.status}`
         setError(String(detail))
-        toast.error(`生成失败: ${String(detail).slice(0, 80)}`)
+        toast.error(t("images.generationFailed", { detail: String(detail).slice(0, 80) }))
         return
       }
 
@@ -63,17 +65,17 @@ export default function ImagePage() {
       }))
 
       if (newImages.length === 0) {
-        setError("未返回图片，请重试")
-        toast.error("未返回图片，请重试")
+        setError(t("images.noImagesReturned"))
+        toast.error(t("images.noImagesReturned"))
         return
       }
 
       setImages(prev => [...newImages, ...prev])
-      toast.success(`成功生成 ${newImages.length} 张图片`)
+      toast.success(t("images.generatedSuccess", { n: newImages.length }))
     } catch (err: any) {
-      const msg = err.message || "网络错误"
+      const msg = err.message || t("images.networkError")
       setError(msg)
-      toast.error(`生成失败: ${msg}`)
+      toast.error(t("images.generationFailed", { detail: msg }))
     } finally {
       setLoading(false)
     }
@@ -91,32 +93,32 @@ export default function ImagePage() {
   return (
     <div className="space-y-6 max-w-5xl">
       <div>
-        <h2 className="text-2xl font-bold tracking-tight">图片生成</h2>
-        <p className="text-muted-foreground">通过 Qwen3.6-Plus 生成 AI 图片，支持多种比例。</p>
+        <h2 className="text-2xl font-bold tracking-tight">{t("images.title")}</h2>
+        <p className="text-muted-foreground">{t("images.subtitle")}</p>
       </div>
 
-      {/* 输入区域 */}
+      {/* Input area */}
       <div className="rounded-xl border bg-card shadow-sm p-6 space-y-4">
         <div className="space-y-2">
-          <label className="text-sm font-medium">图片描述 (Prompt)</label>
+          <label className="text-sm font-medium">{t("images.promptLabel")}</label>
           <textarea
             rows={3}
             value={prompt}
             onChange={e => setPrompt(e.target.value)}
-            placeholder="描述你想生成的图片，例如：赛博朋克风格的猫咪，霓虹灯背景，超写实风格"
+            placeholder={t("images.promptPlaceholder")}
             className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm resize-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             disabled={loading}
             onKeyDown={e => {
               if (e.key === "Enter" && e.ctrlKey) handleGenerate()
             }}
           />
-          <p className="text-xs text-muted-foreground">Ctrl+Enter 快速生成</p>
+          <p className="text-xs text-muted-foreground">{t("images.promptTip")}</p>
         </div>
 
         <div className="flex flex-wrap gap-4 items-end">
-          {/* 比例选择 */}
+          {/* Ratio */}
           <div className="space-y-1.5">
-            <label className="text-sm font-medium">图片比例</label>
+            <label className="text-sm font-medium">{t("images.ratioLabel")}</label>
             <div className="flex gap-2">
               {ASPECT_RATIOS.map(r => (
                 <button
@@ -135,9 +137,9 @@ export default function ImagePage() {
             </div>
           </div>
 
-          {/* 数量选择 */}
+          {/* Count */}
           <div className="space-y-1.5">
-            <label className="text-sm font-medium">生成数量</label>
+            <label className="text-sm font-medium">{t("images.countLabel")}</label>
             <div className="flex gap-2">
               {[1, 2, 4].map(v => (
                 <button
@@ -150,31 +152,31 @@ export default function ImagePage() {
                   }`}
                   disabled={loading}
                 >
-                  {v} 张
+                  {v}
                 </button>
               ))}
             </div>
           </div>
 
-          {/* 尺寸预览 */}
+          {/* Size preview */}
           <div className="text-xs text-muted-foreground font-mono bg-muted/50 border rounded-md px-2 py-1">
             {sizeStr}
           </div>
 
-          {/* 生成按钮 */}
+          {/* Generate button */}
           <Button
             onClick={handleGenerate}
             disabled={loading || !prompt.trim()}
             className="ml-auto h-10 px-6 gap-2"
           >
             {loading
-              ? <><RefreshCw className="h-4 w-4 animate-spin" /> 生成中...</>
-              : <><Wand2 className="h-4 w-4" /> 生成图片</>
+              ? <><RefreshCw className="h-4 w-4 animate-spin" /> {t("images.generating")}</>
+              : <><Wand2 className="h-4 w-4" /> {t("images.generate")}</>
             }
           </Button>
         </div>
 
-        {/* 错误提示 */}
+        {/* Error */}
         {error && (
           <div className="rounded-md bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 text-sm">
             {error}
@@ -182,7 +184,7 @@ export default function ImagePage() {
         )}
       </div>
 
-      {/* 加载状态占位 */}
+      {/* Loading state */}
       {loading && (
         <div className="rounded-xl border bg-card shadow-sm p-8">
           <div className="flex flex-col items-center justify-center gap-4 text-muted-foreground">
@@ -191,20 +193,20 @@ export default function ImagePage() {
               <RefreshCw className="h-6 w-6 animate-spin absolute -bottom-1 -right-1 text-primary" />
             </div>
             <div className="text-center">
-              <p className="font-medium">正在生成图片...</p>
-              <p className="text-sm text-muted-foreground/70 mt-1">图片生成通常需要 10-30 秒，请耐心等待</p>
+              <p className="font-medium">{t("images.loadingState")}</p>
+              <p className="text-sm text-muted-foreground/70 mt-1">{t("images.loadingHint")}</p>
             </div>
           </div>
         </div>
       )}
 
-      {/* 图片展示区 */}
+      {/* Image grid */}
       {images.length > 0 && !loading && (
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="font-semibold">生成结果 ({images.length} 张)</h3>
+            <h3 className="font-semibold">{t("images.resultsTitle", { n: images.length })}</h3>
             <Button variant="ghost" size="sm" onClick={() => setImages([])}>
-              清空
+              {t("images.clearAll")}
             </Button>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -223,9 +225,9 @@ export default function ImagePage() {
                     }}
                   />
                   <div className="hidden items-center justify-center p-8 text-muted-foreground text-sm">
-                    <ImageIcon className="h-8 w-8 mr-2" /> 图片加载失败
+                    <ImageIcon className="h-8 w-8 mr-2" /> {t("images.imageLoadFailed")}
                   </div>
-                  {/* 悬浮操作栏 */}
+                  {/* Hover bar */}
                   <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-3">
                     <Button
                       size="sm"
@@ -233,14 +235,14 @@ export default function ImagePage() {
                       onClick={() => handleDownload(img.url, idx)}
                       className="gap-1.5"
                     >
-                      <Download className="h-3.5 w-3.5" /> 下载
+                      <Download className="h-3.5 w-3.5" /> {t("images.download")}
                     </Button>
                     <Button
                       size="sm"
                       variant="secondary"
                       onClick={() => window.open(img.url, "_blank")}
                     >
-                      在新窗口打开
+                      {t("images.openInNewWindow")}
                     </Button>
                   </div>
                 </div>
@@ -257,14 +259,14 @@ export default function ImagePage() {
         </div>
       )}
 
-      {/* 空状态 */}
+      {/* Empty */}
       {images.length === 0 && !loading && (
         <div className="rounded-xl border bg-card/50 shadow-sm p-12">
           <div className="flex flex-col items-center gap-4 text-muted-foreground">
             <ImageIcon className="h-16 w-16 text-muted-foreground/20" />
             <div className="text-center">
-              <p className="font-medium">还没有生成图片</p>
-              <p className="text-sm text-muted-foreground/70 mt-1">在上方输入描述，点击「生成图片」开始创作</p>
+              <p className="font-medium">{t("images.emptyTitle")}</p>
+              <p className="text-sm text-muted-foreground/70 mt-1">{t("images.emptyHint")}</p>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,8 +4,10 @@ import { Button } from "../components/ui/button"
 import { toast } from "sonner"
 import { getAuthHeader } from "../lib/auth"
 import { API_BASE } from "../lib/api"
+import { useTranslation } from "react-i18next"
 
 export default function SettingsPage() {
+  const { t } = useTranslation()
   const [settings, setSettings] = useState<any>(null)
   const [sessionKey, setSessionKey] = useState("")
   const [maxInflight, setMaxInflight] = useState(4)
@@ -32,28 +34,29 @@ export default function SettingsPage() {
         setPoolTtlMin(Math.round((data.chat_id_pool_ttl_seconds || 600) / 60))
         setModelAliases(JSON.stringify(data.model_aliases || {}, null, 2))
       })
-      .catch(() => toast.error("配置获取失败，请检查会话 Key"))
+      .catch(() => toast.error(t("settings.fetchFailed")))
   }
 
   useEffect(() => {
     loadSessionKey()
     fetchSettings()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleSaveSessionKey = () => {
     if (!sessionKey.trim()) {
-      toast.error("请输入 Key")
+      toast.error(t("settings.sessionKey.keyRequired"))
       return
     }
     localStorage.setItem('qwen2api_key', sessionKey.trim())
-    toast.success("Key 已保存到本地，刷新数据...")
+    toast.success(t("settings.sessionKey.saved"))
     fetchSettings()
   }
 
   const handleClearSessionKey = () => {
     localStorage.removeItem('qwen2api_key')
     setSessionKey("")
-    toast.success("Key 已清除")
+    toast.success(t("settings.sessionKey.cleared"))
   }
 
   const handleSaveConcurrency = () => {
@@ -65,8 +68,8 @@ export default function SettingsPage() {
         global_max_inflight: Number(globalMaxInflight),
       })
     }).then(res => {
-      if(res.ok) { toast.success("并发配置已保存（运行时立即生效）"); fetchSettings(); }
-      else toast.error("保存失败")
+      if(res.ok) { toast.success(t("settings.core.saveConcurrencyToast")); fetchSettings(); }
+      else toast.error(t("settings.saveFailed"))
     })
   }
 
@@ -79,8 +82,8 @@ export default function SettingsPage() {
         chat_id_pool_ttl_seconds: Number(poolTtlMin) * 60,
       })
     }).then(res => {
-      if(res.ok) { toast.success("预热池配置已保存（下一轮刷新生效）"); fetchSettings(); }
-      else toast.error("保存失败")
+      if(res.ok) { toast.success(t("settings.pool.savePoolToast")); fetchSettings(); }
+      else toast.error(t("settings.saveFailed"))
     })
   }
 
@@ -92,11 +95,11 @@ export default function SettingsPage() {
         headers: { "Content-Type": "application/json", ...getAuthHeader() },
         body: JSON.stringify({ model_aliases: parsed })
       }).then(res => {
-        if(res.ok) { toast.success("模型映射规则已更新"); fetchSettings(); }
-        else toast.error("保存失败")
+        if(res.ok) { toast.success(t("settings.modelAliases.saveAliasesToast")); fetchSettings(); }
+        else toast.error(t("settings.saveFailed"))
       })
-    } catch(e) {
-      toast.error("JSON 格式错误，请检查语法")
+    } catch(_e) {
+      toast.error(t("settings.modelAliases.jsonError"))
     }
   }
 
@@ -188,11 +191,11 @@ export default function SettingsPage() {
     <div className="w-full max-w-5xl mx-auto min-w-0 overflow-x-hidden space-y-6">
       <div className="flex justify-between items-center flex-wrap gap-4">
         <div className="min-w-0">
-          <h2 className="text-2xl font-bold tracking-tight">系统设置</h2>
-          <p className="text-muted-foreground">管理控制台认证与网关运行时配置。</p>
+          <h2 className="text-2xl font-bold tracking-tight">{t("settings.title")}</h2>
+          <p className="text-muted-foreground">{t("settings.subtitle")}</p>
         </div>
-        <Button variant="outline" onClick={() => {fetchSettings(); toast.success("配置已刷新")}}>
-          <RefreshCw className="mr-2 h-4 w-4" /> 刷新配置
+        <Button variant="outline" onClick={() => {fetchSettings(); toast.success(t("settings.configRefreshed"))}}>
+          <RefreshCw className="mr-2 h-4 w-4" /> {t("settings.refreshConfig")}
         </Button>
       </div>
 
@@ -202,9 +205,9 @@ export default function SettingsPage() {
           <div className="flex flex-col space-y-1.5 p-6 border-b bg-muted/30">
             <div className="flex items-center gap-2">
               <KeyRound className="h-5 w-5 text-primary" />
-              <h3 className="font-semibold leading-none tracking-tight">当前会话 Key</h3>
+              <h3 className="font-semibold leading-none tracking-tight">{t("settings.sessionKey.title")}</h3>
             </div>
-            <p className="text-sm text-muted-foreground">将已有的 API Key 粘贴到此处，控制台将使用它进行所有的管理操作。（保存在浏览器本地）</p>
+            <p className="text-sm text-muted-foreground">{t("settings.sessionKey.subtitle")}</p>
           </div>
           <div className="p-6">
             <div className="flex gap-2 items-center flex-wrap">
@@ -212,11 +215,11 @@ export default function SettingsPage() {
                 type="password"
                 value={sessionKey}
                 onChange={e => setSessionKey(e.target.value)}
-                placeholder="sk-qwen-... 或默认管理员密钥 admin"
+                placeholder={t("settings.sessionKey.placeholder")}
                 className="flex h-10 flex-1 min-w-[200px] rounded-md border border-input bg-background px-3 py-2 text-sm"
               />
-              <Button onClick={handleSaveSessionKey}>保存</Button>
-              <Button variant="ghost" onClick={handleClearSessionKey}>清除</Button>
+              <Button onClick={handleSaveSessionKey}>{t("common.save")}</Button>
+              <Button variant="ghost" onClick={handleClearSessionKey}>{t("common.clear")}</Button>
             </div>
           </div>
         </div>
@@ -226,12 +229,12 @@ export default function SettingsPage() {
           <div className="flex flex-col space-y-1.5 p-6 border-b bg-muted/30">
             <div className="flex items-center gap-2">
               <ServerCrash className="h-5 w-5 text-primary" />
-              <h3 className="font-semibold leading-none tracking-tight">连接信息</h3>
+              <h3 className="font-semibold leading-none tracking-tight">{t("settings.connection.title")}</h3>
             </div>
           </div>
           <div className="p-6">
             <div className="space-y-1 min-w-0">
-              <label className="text-sm font-medium">API 基础地址 (Base URL)</label>
+              <label className="text-sm font-medium">{t("settings.connection.baseUrlLabel")}</label>
               <input type="text" readOnly value={baseUrl} className="flex h-10 w-full rounded-md border border-input bg-muted px-3 py-2 text-sm font-mono text-muted-foreground" />
             </div>
           </div>
@@ -242,21 +245,21 @@ export default function SettingsPage() {
           <div className="flex flex-col space-y-1.5 p-6 border-b bg-muted/30">
             <div className="flex items-center gap-2">
               <Settings2 className="h-5 w-5 text-primary" />
-              <h3 className="font-semibold leading-none tracking-tight">核心并发参数</h3>
+              <h3 className="font-semibold leading-none tracking-tight">{t("settings.core.title")}</h3>
             </div>
-            <p className="text-sm text-muted-foreground">运行时并发槽位与排队阈值（需要在后端 config.json 中修改后重启生效）。</p>
+            <p className="text-sm text-muted-foreground">{t("settings.core.subtitle")}</p>
           </div>
           <div className="p-6 space-y-4">
             <div className="flex justify-between items-center py-2 border-b flex-wrap gap-2">
               <div className="space-y-1 min-w-0">
-                <span className="text-sm font-medium">当前系统版本</span>
+                <span className="text-sm font-medium">{t("settings.core.version")}</span>
               </div>
               <span className="font-mono text-sm">{settings?.version || "..."}</span>
             </div>
             <div className="flex justify-between items-center py-2 border-b flex-wrap gap-4">
               <div className="space-y-1 min-w-0 flex-1">
-                <span className="text-sm font-medium">单账号最大并发 (max_inflight_per_account)</span>
-                <p className="text-xs text-muted-foreground">每个上游账号同时处理的请求数。太大易被封，太小不充分利用。</p>
+                <span className="text-sm font-medium">{t("settings.core.maxInflightLabel")}</span>
+                <p className="text-xs text-muted-foreground">{t("settings.core.maxInflightDesc")}</p>
               </div>
               <input
                 type="number"
@@ -269,8 +272,8 @@ export default function SettingsPage() {
             </div>
             <div className="flex justify-between items-center py-2 border-b flex-wrap gap-4">
               <div className="space-y-1 min-w-0 flex-1">
-                <span className="text-sm font-medium">全局并发上限 (global_max_inflight)</span>
-                <p className="text-xs text-muted-foreground">所有账号合计同时在途请求的硬上限。0 = 不限。对应 Dashboard 的"异步任务"峰值。</p>
+                <span className="text-sm font-medium">{t("settings.core.globalMaxInflightLabel")}</span>
+                <p className="text-xs text-muted-foreground">{t("settings.core.globalMaxInflightDesc")}</p>
               </div>
               <input
                 type="number"
@@ -282,7 +285,7 @@ export default function SettingsPage() {
               />
             </div>
             <div className="flex justify-end">
-              <Button size="sm" onClick={handleSaveConcurrency}>保存并发设置</Button>
+              <Button size="sm" onClick={handleSaveConcurrency}>{t("settings.core.saveConcurrency")}</Button>
             </div>
           </div>
         </div>
@@ -292,15 +295,15 @@ export default function SettingsPage() {
           <div className="flex flex-col space-y-1.5 p-6 border-b bg-muted/30">
             <div className="flex items-center gap-2">
               <Settings2 className="h-5 w-5 text-rose-500" />
-              <h3 className="font-semibold leading-none tracking-tight">Chat_ID 预热池</h3>
+              <h3 className="font-semibold leading-none tracking-tight">{t("settings.pool.title")}</h3>
             </div>
-            <p className="text-sm text-muted-foreground">预建 chat_id 规避上游 /chats/new 握手 (0.5~6s)。运行时修改立即生效。</p>
+            <p className="text-sm text-muted-foreground">{t("settings.pool.subtitle")}</p>
           </div>
           <div className="p-6 space-y-4">
             <div className="flex justify-between items-center py-2 border-b flex-wrap gap-4">
               <div className="space-y-1 min-w-0 flex-1">
-                <span className="text-sm font-medium">每账号目标数 (target)</span>
-                <p className="text-xs text-muted-foreground">每个账号预先挂多少个 chat_id 等着。默认 5。</p>
+                <span className="text-sm font-medium">{t("settings.pool.targetLabel")}</span>
+                <p className="text-xs text-muted-foreground">{t("settings.pool.targetDesc")}</p>
               </div>
               <input
                 type="number"
@@ -313,8 +316,8 @@ export default function SettingsPage() {
             </div>
             <div className="flex justify-between items-center py-2 border-b flex-wrap gap-4">
               <div className="space-y-1 min-w-0 flex-1">
-                <span className="text-sm font-medium">TTL (分钟)</span>
-                <p className="text-xs text-muted-foreground">chat_id 超过此时长则丢弃重建，避免被上游静默回收。默认 10。</p>
+                <span className="text-sm font-medium">{t("settings.pool.ttlLabel")}</span>
+                <p className="text-xs text-muted-foreground">{t("settings.pool.ttlDesc")}</p>
               </div>
               <input
                 type="number"
@@ -326,7 +329,7 @@ export default function SettingsPage() {
               />
             </div>
             <div className="flex justify-end">
-              <Button size="sm" onClick={handleSavePool}>保存预热池设置</Button>
+              <Button size="sm" onClick={handleSavePool}>{t("settings.pool.savePool")}</Button>
             </div>
           </div>
         </div>
@@ -334,8 +337,8 @@ export default function SettingsPage() {
         {/* Model Mapping */}
         <div className="rounded-xl border bg-card text-card-foreground shadow-sm min-w-0">
           <div className="flex flex-col space-y-1.5 p-6 border-b bg-muted/30">
-            <h3 className="font-semibold leading-none tracking-tight">自动模型映射规则 (Model Aliases)</h3>
-            <p className="text-sm text-muted-foreground">下游传入的模型名称将被网关自动路由至以下千问实际模型。请使用标准 JSON 格式编辑。</p>
+            <h3 className="font-semibold leading-none tracking-tight">{t("settings.modelAliases.title")}</h3>
+            <p className="text-sm text-muted-foreground">{t("settings.modelAliases.subtitle")}</p>
           </div>
           <div className="p-6">
             <textarea
@@ -346,7 +349,7 @@ export default function SettingsPage() {
               style={{ whiteSpace: "pre", overflowX: "auto" }}
             />
             <div className="mt-4 flex justify-end">
-              <Button onClick={handleSaveAliases}>保存映射</Button>
+              <Button onClick={handleSaveAliases}>{t("settings.modelAliases.saveAliases")}</Button>
             </div>
           </div>
         </div>
@@ -356,7 +359,7 @@ export default function SettingsPage() {
           <div className="flex flex-col space-y-1.5 p-6 border-b bg-muted/30">
             <div className="flex items-center gap-2">
               <Code className="h-5 w-5 text-primary" />
-              <h3 className="font-semibold leading-none tracking-tight">使用示例</h3>
+              <h3 className="font-semibold leading-none tracking-tight">{t("settings.example.title")}</h3>
             </div>
           </div>
           <div className="p-6 min-w-0">

--- a/frontend/src/pages/TestPage.tsx
+++ b/frontend/src/pages/TestPage.tsx
@@ -4,8 +4,9 @@ import { Send, RefreshCw, Bot } from "lucide-react"
 import { getAuthHeader } from "../lib/auth"
 import { API_BASE } from "../lib/api"
 import { toast } from "sonner"
+import { useTranslation } from "react-i18next"
 
-// 渲染消息内容：自动把 Markdown 图片和图片 URL 渲染成 <img>
+// Renders message content: auto-converts Markdown images and image URLs to <img>
 function MessageContent({ content }: { content: string }) {
   type Seg = { start: number; end: number; url: string }
   const segs: Seg[] = []
@@ -46,6 +47,7 @@ function MessageContent({ content }: { content: string }) {
 }
 
 export default function TestPage() {
+  const { t } = useTranslation()
   const [messages, setMessages] = useState<{ role: string; content: string; reasoning?: string; error?: boolean }[]>([])
   const [input, setInput] = useState("")
   const [loading, setLoading] = useState(false)
@@ -58,7 +60,7 @@ export default function TestPage() {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" })
   }, [messages])
 
-  // 挂载时从 /v1/models 拉真实模型列表，失败回退到默认三项
+  // On mount, fetch real model list from /v1/models. Fallback to default list on failure.
   useEffect(() => {
     (async () => {
       try {
@@ -99,7 +101,7 @@ export default function TestPage() {
         } else if (data.choices?.[0]) {
           setMessages(prev => [...prev, data.choices[0].message])
         } else {
-          setMessages(prev => [...prev, { role: "assistant", content: `❌ 未知响应: ${JSON.stringify(data)}`, error: true }])
+          setMessages(prev => [...prev, { role: "assistant", content: `❌ ${t("test.unknownResponse", { response: JSON.stringify(data) })}`, error: true }])
         }
       } else {
         const res = await fetch(`${API_BASE}/v1/chat/completions`, {
@@ -164,14 +166,14 @@ export default function TestPage() {
         if (!hasContent) {
           setMessages(prev => {
             const msgs = [...prev]
-            msgs[msgs.length - 1] = { role: "assistant", content: "❌ 响应为空（账号可能未激活或无可用账号）", error: true }
+            msgs[msgs.length - 1] = { role: "assistant", content: `❌ ${t("test.emptyResponse")}`, error: true }
             return msgs
           })
         }
       }
     } catch (err: any) {
-      toast.error(`网络错误: ${err.message}`)
-      setMessages(prev => [...prev, { role: "assistant", content: `❌ 网络错误: ${err.message}`, error: true }])
+      toast.error(t("test.networkError", { message: err.message }))
+      setMessages(prev => [...prev, { role: "assistant", content: `❌ ${t("test.networkError", { message: err.message })}`, error: true }])
     } finally {
       setLoading(false)
     }
@@ -181,12 +183,12 @@ export default function TestPage() {
     <div className="flex flex-col h-[calc(100vh-10rem)] space-y-4 max-w-5xl mx-auto">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">接口测试</h2>
-          <p className="text-muted-foreground">在此测试您的 API 分发是否正常工作。</p>
+          <h2 className="text-2xl font-bold tracking-tight">{t("test.title")}</h2>
+          <p className="text-muted-foreground">{t("test.subtitle")}</p>
         </div>
         <div className="flex gap-4 items-center">
           <div className="flex items-center gap-2 text-sm bg-card border px-3 py-1.5 rounded-md">
-            <span className="font-medium text-muted-foreground">模型:</span>
+            <span className="font-medium text-muted-foreground">{t("test.modelLabel")}</span>
             <select value={model} onChange={e => setModel(e.target.value)} className="bg-transparent font-mono outline-none">
               {availableModels.map(id => (
                 <option key={id} value={id}>{id}</option>
@@ -198,10 +200,10 @@ export default function TestPage() {
             onClick={() => setStream(!stream)}
           >
             <input type="checkbox" checked={stream} onChange={() => {}} className="cursor-pointer" />
-            <span className="font-medium">流式传输 (Stream)</span>
+            <span className="font-medium">{t("test.stream")}</span>
           </div>
           <Button variant="outline" onClick={() => setMessages([])}>
-            <RefreshCw className="mr-2 h-4 w-4" /> 清空对话
+            <RefreshCw className="mr-2 h-4 w-4" /> {t("test.clear")}
           </Button>
         </div>
       </div>
@@ -211,7 +213,7 @@ export default function TestPage() {
           {messages.length === 0 && (
             <div className="h-full flex flex-col items-center justify-center text-muted-foreground space-y-4">
               <Bot className="h-12 w-12 text-muted-foreground/30" />
-              <p className="text-sm">发送一条消息以开始测试，系统将通过 /v1/chat/completions 进行调用。</p>
+              <p className="text-sm">{t("test.empty")}</p>
             </div>
           )}
           {messages.map((msg, i) => (
@@ -224,14 +226,14 @@ export default function TestPage() {
                     : "bg-muted/30 border text-foreground"}`}>
                 {msg.role === "assistant" && !msg.content && !msg.reasoning && loading ? (
                   <span className="animate-pulse flex items-center gap-2 text-muted-foreground">
-                    <Bot className="h-4 w-4" /> 思考中...
+                    <Bot className="h-4 w-4" /> {t("test.thinking")}
                   </span>
                 ) : msg.role === "assistant" && !msg.error ? (
                   <div className="space-y-2">
                     {msg.reasoning ? (
                       <details open className="rounded-md border border-dashed border-border/50 bg-muted/20 p-2 text-xs">
                         <summary className="cursor-pointer select-none text-muted-foreground font-mono">
-                          💭 思考过程 ({msg.reasoning.length} 字)
+                          💭 {t("test.thinkingProcess")} ({t("test.thinkingChars", { n: msg.reasoning.length })})
                         </summary>
                         <div className="whitespace-pre-wrap leading-relaxed text-muted-foreground mt-2 pl-2 border-l-2 border-border/30">
                           {msg.reasoning}
@@ -256,7 +258,7 @@ export default function TestPage() {
             onChange={e => setInput(e.target.value)}
             onKeyDown={e => e.key === "Enter" && handleSend()}
             className="flex h-12 w-full rounded-md border border-input bg-background px-4 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-            placeholder="输入测试消息..."
+            placeholder={t("test.inputPlaceholder")}
             disabled={loading}
           />
           <Button onClick={handleSend} disabled={loading || !input.trim()} className="h-12 px-6">

--- a/frontend/src/pages/TokensPage.tsx
+++ b/frontend/src/pages/TokensPage.tsx
@@ -4,8 +4,10 @@ import { Plus, RefreshCw, Copy, Check, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 import { getAuthHeader } from "../lib/auth"
 import { API_BASE } from "../lib/api"
+import { useTranslation } from "react-i18next"
 
 export default function TokensPage() {
+  const { t } = useTranslation()
   const [keys, setKeys] = useState<string[]>([])
   const [copied, setCopied] = useState<string | null>(null)
 
@@ -16,11 +18,12 @@ export default function TokensPage() {
         return res.json()
       })
       .then(data => setKeys(data.keys || []))
-      .catch(() => toast.error("刷新失败，请检查会话 Key"))
+      .catch(() => toast.error(t("tokens.fetchFailed")))
   }
 
   useEffect(() => {
     fetchKeys()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleGenerate = () => {
@@ -30,13 +33,13 @@ export default function TokensPage() {
     }).then(async res => {
       const data = await res.json().catch(() => ({}))
       if (res.ok) {
-        toast.success("已生成新的 API Key")
+        toast.success(t("tokens.generated"))
         if (data.key) copyToClipboard(data.key)
         fetchKeys()
       } else {
-        toast.error(data.detail || "生成失败，请检查权限")
+        toast.error(data.detail || t("tokens.generateFailed"))
       }
-    }).catch(() => toast.error("生成失败，请检查权限"))
+    }).catch(() => toast.error(t("tokens.generateFailed")))
   }
 
   const handleDelete = (key: string) => {
@@ -45,13 +48,13 @@ export default function TokensPage() {
       headers: getAuthHeader()
     }).then(async res => {
       if (res.ok) {
-        toast.success("API Key 已删除")
+        toast.success(t("tokens.deleted"))
         fetchKeys()
       } else {
         const data = await res.json().catch(() => ({}))
-        toast.error(data.detail || "删除失败")
+        toast.error(data.detail || t("tokens.deleteFailed"))
       }
-    }).catch(() => toast.error("删除失败"))
+    }).catch(() => toast.error(t("tokens.deleteFailed")))
   }
 
   const copyToClipboard = (text: string) => {
@@ -64,15 +67,15 @@ export default function TokensPage() {
     <div className="space-y-6 max-w-4xl">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">API Key 分发</h2>
-          <p className="text-muted-foreground">管理可以访问此网关的下游凭证。</p>
+          <h2 className="text-2xl font-bold tracking-tight">{t("tokens.title")}</h2>
+          <p className="text-muted-foreground">{t("tokens.subtitle")}</p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => { fetchKeys(); toast.success("已刷新"); }}>
-            <RefreshCw className="mr-2 h-4 w-4" /> 刷新
+          <Button variant="outline" onClick={() => { fetchKeys(); toast.success(t("tokens.refreshed")); }}>
+            <RefreshCw className="mr-2 h-4 w-4" /> {t("tokens.refresh")}
           </Button>
           <Button onClick={handleGenerate}>
-            <Plus className="mr-2 h-4 w-4" /> 生成新 Key
+            <Plus className="mr-2 h-4 w-4" /> {t("tokens.generate")}
           </Button>
         </div>
       </div>
@@ -81,15 +84,15 @@ export default function TokensPage() {
         <table className="w-full text-sm text-left">
           <thead className="bg-muted/50 border-b text-muted-foreground">
             <tr>
-              <th className="h-12 px-4 align-middle font-medium w-16">序号</th>
+              <th className="h-12 px-4 align-middle font-medium w-16">{t("tokens.table.index")}</th>
               <th className="h-12 px-4 align-middle font-medium">API Key</th>
-              <th className="h-12 px-4 align-middle font-medium text-right">操作</th>
+              <th className="h-12 px-4 align-middle font-medium text-right">{t("tokens.table.actions")}</th>
             </tr>
           </thead>
           <tbody>
             {keys.length === 0 && (
               <tr>
-                <td colSpan={3} className="p-4 text-center text-muted-foreground">暂无 API Key</td>
+                <td colSpan={3} className="p-4 text-center text-muted-foreground">{t("tokens.table.empty")}</td>
               </tr>
             )}
             {keys.map((k, i) => (


### PR DESCRIPTION
## Summary

Adds full internationalization (i18n) support to the admin WebUI using **react-i18next**, with **English** and **Português (Brasil)** locale bundles. A language switcher dropdown is added to the bottom of the sidebar; the choice is persisted in `localStorage` (`qwen2api_lang`).

Also translates user-facing strings in two backend files (`admin.py` response messages and `pool_core.py` status map) so non-Chinese-reading admins see English text in toasts and API responses.

The original Chinese strings are not preserved as a bundle in this PR — the consensus on the original Issue tracker / `README.en.md` already targets English-speaking deployers, and the UI now defaults to English while supporting pt-BR. If the project wants Chinese kept as a bundle, I'm happy to add a `zh.json` and set Chinese as the default `fallbackLng` — let me know.

## Changes

**Frontend (`frontend/`)**
- New deps: `i18next`, `react-i18next`, `i18next-browser-languagedetector`
- `src/i18n/index.ts` — initialization with `localStorage` → `navigator` → `htmlTag` detection chain
- `src/i18n/locales/en.json`, `src/i18n/locales/pt-BR.json` — ~150 translation keys each
- `src/main.tsx` — imports `./i18n` once at boot
- `src/layouts/AdminLayout.tsx` — sidebar menu items use `t()`; added language switcher footer
- `src/pages/{Dashboard,AccountsPage,TokensPage,TestPage,ImagePage,SettingsPage}.tsx` — replaced all hardcoded strings with `t()` calls, using `{{var}}` interpolation for dynamic values (account counts, error details, etc.)

**Backend (`backend/`)**
- `api/admin.py` — 6 user-facing error/success messages translated (registration, activation, validation flows)
- `core/account_pool/pool_core.py` — `status_map` returns English status labels (the frontend now handles localization independently, so the API can return canonical English)

## Test plan

- [x] `cd frontend && npm install && npm run build` — succeeds, 1786 modules transformed, no errors
- [x] Vite bundle contains both `en` and `pt-BR` resource bundles
- [ ] Reviewer: open `/settings`, switch language via sidebar dropdown — all visible strings reflect the chosen locale
- [ ] Reviewer: trigger toast messages (save key, generate API key, verify account) — toast text matches the selected language
- [ ] Reviewer: admin error paths return English strings from the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)