### PR TITLE
fix(frontend): 修复流式响应SSE解析截断导致JSON解析失败

### DIFF
--- a/frontend/src/pages/TestPage.tsx
+++ b/frontend/src/pages/TestPage.tsx
@@ -120,13 +120,18 @@ export default function TestPage() {
         const reader = res.body.getReader()
         const decoder = new TextDecoder()
         let hasContent = false
+        let buffer = ""
 
         while (true) {
           const { done, value } = await reader.read()
           if (done) break
 
-          const chunk = decoder.decode(value, { stream: true })
-          for (const rawLine of chunk.split("\n")) {
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split("\n")
+          // Keep the last potentially incomplete line in the buffer
+          buffer = lines.pop() || ""
+
+          for (const rawLine of lines) {
             const line = rawLine.trim()
             if (!line || line.startsWith(":") || line === "data: [DONE]") continue
             if (line.startsWith("data: ")) {
@@ -156,8 +161,33 @@ export default function TestPage() {
                     return msgs
                   })
                 }
-              } catch { /* skip */ }
+              } catch { /* skip malformed JSON chunks */ }
             }
+          }
+        }
+
+        // Process any remaining data in the buffer
+        if (buffer.trim()) {
+          const line = buffer.trim()
+          if (line.startsWith("data: ") && line !== "data: [DONE]") {
+            try {
+              const data = JSON.parse(line.slice(6))
+              const content: string = data.choices?.[0]?.delta?.content ?? ""
+              const reasoning: string = data.choices?.[0]?.delta?.reasoning_content ?? ""
+              if (content || reasoning) {
+                hasContent = true
+                setMessages(prev => {
+                  const msgs = [...prev]
+                  const last = msgs[msgs.length - 1]
+                  msgs[msgs.length - 1] = {
+                    ...last,
+                    content: last.content + content,
+                    reasoning: (last.reasoning || "") + reasoning,
+                  }
+                  return msgs
+                })
+              }
+            } catch { /* skip */ }
           }
         }
 


### PR DESCRIPTION
## 问题描述
修复 Issue #12: 接口测试页面勾选了流式传输，实际上并不是真正的流式输出。
### 根本原因
前端 `TestPage.tsx` 中的 SSE 流式解析逻辑存在 bug：直接使用 `chunk.split("\n")` 分割数据，但没有处理 chunk 边界截断的情况。当网络传输的 chunk 恰好在 JSON 数据行中间断开时，会导致：
前半部分 JSON 不完整，`JSON.parse()` 抛出异常被 catch 吞掉
后半部分缺少 `data: ` 前缀，被直接跳过
用户看到的现象就是"流式传输不工作"或回复内容丢失/中断
### 修复方案
引入 buffer 缓冲机制：
1. 每次读取 chunk 后追加到 buffer
2. 按换行符分割，只处理完整的行（以 \n 结尾的部分）
3. 未完成的最后一行保留在 buffer 中，等待下一个 chunk 拼接
4. stream 结束后处理 buffer 中剩余的数据
### 测试验证
✅ 流式传输正常逐字输出
✅ 长回复不会丢失内容
✅ chunk 边界截断场景正确处理
✅ 非流式模式不受影响
Closes #12