### PR TITLE
从 README 中移除发布无用徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Telegram 群聊: [https://t.me/qwen2api](https://t.me/qwen2api)
 
 [![Stars](https://img.shields.io/github/stars/YuJunZhiXue/qwen2API?style=flat-square)](https://github.com/YuJunZhiXue/qwen2API/stargazers)
 [![Forks](https://img.shields.io/github/forks/YuJunZhiXue/qwen2API?style=flat-square)](https://github.com/YuJunZhiXue/qwen2API/network/members)
-[![Release](https://img.shields.io/github/v/release/YuJunZhiXue/qwen2API?style=flat-square)](https://github.com/YuJunZhiXue/qwen2API/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/yujunzhixue/qwen2api?style=flat-square)](https://hub.docker.com/r/yujunzhixue/qwen2api)
 
 语言 / Language: [中文](./README.md)


### PR DESCRIPTION
删除README无用的证书文件链接╰(*°▽°*)╯